### PR TITLE
Updating movement - non-blocking operations, new code structure, custom user commands

### DIFF
--- a/FluidNC/src/Machine/Homing.cpp
+++ b/FluidNC/src/Machine/Homing.cpp
@@ -427,7 +427,7 @@ namespace Machine {
     // cycle.  The protocol loop will then respond to events and advance
     // the homing state machine through its phases.
     void Homing::run_cycles(AxisMask axisMask) {
-        Maslow.home(axisMask);
+        //Maslow.home(axisMask);
         if (!config->_kinematics->canHome(axisMask)) {
             sys.set_state(State::Alarm);
             return;

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -114,9 +114,9 @@ void Maslow_::begin(void (*sys_rt)()) {
 
 }
 
-void printToWeb (double precision){
-    log_info( "Calibration Precision: " << precision << "mm");
-}
+// void printToWeb (double precision){
+//     log_info( "Calibration Precision: " << precision << "mm");
+// }
 
 void Maslow_::home(int axis) {
     log_info(axis);
@@ -169,7 +169,6 @@ void Maslow_::home(int axis) {
     }
 }
 
-
 void Maslow_::update(){
     Maslow.updateEncoderPositions();
     if(!Maslow.using_default_config && ( sys.state() == State::Jog || sys.state() == State::Cycle ) ){
@@ -178,7 +177,7 @@ void Maslow_::update(){
     }
     //else Maslow.stopMotors();
 }
-
+//updating encoder positions for all 4 arms
 bool Maslow_::updateEncoderPositions(){
     bool success = true;
     if(!readingFromSD){
@@ -1004,95 +1003,4 @@ Maslow_ &Maslow_::getInstance() {
 }
 
 
-
-
 Maslow_ &Maslow = Maslow.getInstance();
-
-
-// void Maslow_::readEncoders() {
-//   axisTL.readEncoder();
-//   axisTR.readEncoder();
-//   axisBL.readEncoder();
-//   axisBR.readEncoder();
-// }
-
-// float Maslow_::computeVertical(float firstUpper, float firstLower, float secondUpper, float secondLower){
-//     //Derivation at https://math.stackexchange.com/questions/4090346/solving-for-triangle-side-length-with-limited-information
-    
-//     float b = secondUpper;   //upper, second
-//     float c = secondLower; //lower, second
-//     float d = firstUpper; //upper, first
-//     float e = firstLower;  //lower, first
-
-//     float aSquared = (((b*b)-(c*c))*((b*b)-(c*c))-((d*d)-(e*e))*((d*d)-(e*e)))/(2*(b*b+c*c-d*d-e*e));
-
-//     float a = sqrt(aSquared);
-    
-//     return a;
-// }
-
-// void Maslow_::computeFrameDimensions(float lengthsSet1[], float lengthsSet2[], float machineDimensions[]){
-//     //Call compute verticals from each side
-    
-//     float leftHeight = computeVertical(lengthsSet1[3],lengthsSet1[0], lengthsSet2[3], lengthsSet2[0]);
-//     float rightHeight = computeVertical(lengthsSet1[2],lengthsSet1[1], lengthsSet2[2], lengthsSet2[1]);
-    
-//     //log_info( "Computed vertical measurements:\n%f \n%f \n%f \n",leftHeight, rightHeight, (leftHeight+rightHeight)/2.0);
-// }
-
-// void Maslow_::lowerBeltsGoSlack(){
-//     //log_info( "Lower belts going slack");
-    
-//     unsigned long startTime = millis();
-
-//     axisBL.setTarget(axisBL.getPosition() + 2);
-//     axisBR.setTarget(axisBR.getPosition() + 2);
-    
-//     while(millis()- startTime < 600){
-
-//         axisBL.recomputePID();
-//         axisBR.recomputePID();
-//         axisTR.recomputePID();
-//         axisTL.recomputePID();
-//         axisTR.updateEncoderPosition();
-//         axisTL.updateEncoderPosition();
-//         axisBR.updateEncoderPosition();
-//         axisBL.updateEncoderPosition();
-
-//         (*_sys_rt)();
-        
-//         // Delay without blocking
-//         unsigned long time = millis();
-//         unsigned long elapsedTime = millis()-time;
-//         while(elapsedTime < 10){
-//             elapsedTime = millis()-time;
-//         }
-//     }
-
-//     //Then stop them before moving on
-//     startTime = millis();
-
-//     axisBL.setTarget(axisBL.getPosition());
-//     axisBR.setTarget(axisBR.getPosition());
-
-//     while(millis()- startTime < 600){
-
-//         axisBL.recomputePID();
-//         axisBR.recomputePID();
-//         axisTR.recomputePID();
-//         axisTL.recomputePID();
-//         axisTR.updateEncoderPosition();
-//         axisTL.updateEncoderPosition();
-//         axisBR.updateEncoderPosition();
-//         axisBL.updateEncoderPosition();
-
-//         (*_sys_rt)();
-
-//     }
-
-//     //grbl_sendf( "Going slack completed\n");
-// }
-
-// void Maslow_::printMeasurements(float lengths[]){
-//     //log_info( "{bl:" + String(lengths[0]) + ",   br:" + String(lengths[1]) + ",   tr:" + String(lengths[2]) + ",   tl:" + String(lengths[3]) + "}");
-// }

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -181,6 +181,12 @@ void Maslow_::update(){
         else if(sys.state() == State::Homing){
 
             //run all the retract functions untill we hit the current limit
+            if(retractingBR){
+                if( axisBR.retract() ) retractingBR = false;
+                if(random(40) == 10){
+                    log_info(axisBR.getCurrent());
+                }
+            }
             if(retractingTL){
                 if( axisTL.retract() ) retractingTL = false;
             }
@@ -190,17 +196,15 @@ void Maslow_::update(){
             if(retractingBL){
                 if( axisBL.retract() ) retractingBL = false;
             }
-            if(retractingBR){
-                if( axisBR.retract() ) retractingBR = false;
-            }
+
             //Extending routines
             if (extendingALL) {
                 //decompress belts for the first half second
                 if (millis() - extendCallTimer < 500) {
-                    axisBR.decompressBelt();
-                    axisBL.decompressBelt();
-                    axisTR.decompressBelt();
-                    axisTL.decompressBelt();
+                    if( millis() - extendCallTimer >0) axisBR.decompressBelt();
+                    if (millis() - extendCallTimer > 100) axisBL.decompressBelt();
+                    if (millis() - extendCallTimer > 150) axisTR.decompressBelt();
+                    if (millis() - extendCallTimer > 200) axisTL.decompressBelt();
                 } 
                 //then make all the belts comply until they are extended fully, or user terminates it
                 else {
@@ -214,10 +218,10 @@ void Maslow_::update(){
             if(complyALL){
                 //decompress belts for the first half second
                 if (millis() - complyCallTimer < 500) {
-                    axisBR.decompressBelt();
-                    axisBL.decompressBelt();
-                    axisTR.decompressBelt();
-                    axisTL.decompressBelt();
+                    if( millis() - complyCallTimer >0) axisBR.decompressBelt();
+                    if (millis() - complyCallTimer > 100) axisBL.decompressBelt();
+                    if (millis() - complyCallTimer > 150) axisTR.decompressBelt();
+                    if (millis() - complyCallTimer > 200) axisTL.decompressBelt();
                 } else {
                     axisTL.comply(500);  //call to recomputePID() inside here
                     axisTR.comply(500);

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -47,11 +47,6 @@ class Maslow_ {
     void takeUpInternalSlack();
     void retractBR();
     void retractBL();
-    //void readEncoders();
-    //float computeVertical(float firstUpper, float firstLower, float secondUpper, float secondLower);
-    //void computeFrameDimensions(float lengthsSet1[], float lengthsSet2[], float machineDimensions[]);
-    //void printMeasurements(float lengths[]);
-    //void lowerBeltsGoSlack();
     
     
     MotorUnit axisTL;

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -54,10 +54,14 @@ class Maslow_ {
     void retractBL();
     void retractBR();
     void retractALL();
+    void extendALL();
+    void comply();
     bool retractingTL = false;
     bool retractingTR = false;
     bool retractingBL = false;
     bool retractingBR = false; 
+    bool extendingALL = false;
+    bool complyALL = false;
     
     
     MotorUnit axisTL;
@@ -102,6 +106,8 @@ class Maslow_ {
     unsigned long lastCallToPID = millis();
     unsigned long lastMiss = millis();
     unsigned long lastCallToUpdate = millis();
+    unsigned long extendCallTimer = millis();
+    unsigned long complyCallTimer = millis();
 
     //Stores a reference to the global system runtime function to be called when blocking operations are needed
     void (*_sys_rt)() = nullptr;

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -56,10 +56,17 @@ class Maslow_ {
     void retractALL();
     void extendALL();
     void comply();
+    void stop();
     bool retractingTL = false;
     bool retractingTR = false;
     bool retractingBL = false;
-    bool retractingBR = false; 
+    bool retractingBR = false;
+    
+    bool extendedTL   = false;
+    bool extendedTR   = false;
+    bool extendedBL   = false;
+    bool extendedBR   = false;
+
     bool extendingALL = false;
     bool complyALL = false;
     

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -19,20 +19,24 @@ class Maslow_ {
     Maslow_ &operator=(const Maslow_ &) = delete;
 
   public:
+    //main utility functions
     void begin(void (*sys_rt)());
-    //void readEncoders();
     void home(int axis);
-    void updateCenterXY();
+    void update();
+    bool updateEncoderPositions();
+    void setTargets(float xTarget, float yTarget, float zTarget);
     void recomputePID();
+
+    //math 
+    void updateCenterXY();
     void computeTensions(float x, float y);
     float computeBL(float x, float y, float z);
     float computeBR(float x, float y, float z);
     float computeTR(float x, float y, float z);
     float computeTL(float x, float y, float z);
-    void setTargets(float xTarget, float yTarget, float zTarget);
+
+    //calibration functions 
     void runCalibration();
-    void printMeasurements(float lengths[]);
-    void lowerBeltsGoSlack();
     void printMeasurementSet(float allLengths[][4]);
     void takeColumnOfMeasurements(float x, float measurments[][4]);
     float printMeasurementMetrics(double avg, double m1, double m2, double m3, double m4, double m5);
@@ -41,15 +45,15 @@ class Maslow_ {
     void takeMeasurement(float lengths[]);
     void moveWithSlack(float x, float y, bool leftBelt, bool rightBelt);
     void takeUpInternalSlack();
-    float computeVertical(float firstUpper, float firstLower, float secondUpper, float secondLower);
-    void computeFrameDimensions(float lengthsSet1[], float lengthsSet2[], float machineDimensions[]);
     void retractBR();
     void retractBL();
+    //void readEncoders();
+    //float computeVertical(float firstUpper, float firstLower, float secondUpper, float secondLower);
+    //void computeFrameDimensions(float lengthsSet1[], float lengthsSet2[], float machineDimensions[]);
+    //void printMeasurements(float lengths[]);
+    //void lowerBeltsGoSlack();
     
-
-
-
-
+    
     MotorUnit axisTL;
     MotorUnit axisTR;
     MotorUnit axisBL;

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -45,8 +45,19 @@ class Maslow_ {
     void takeMeasurement(float lengths[]);
     void moveWithSlack(float x, float y, bool leftBelt, bool rightBelt);
     void takeUpInternalSlack();
-    void retractBR();
+    void retractBR_CAL();
+    void retractBL_CAL();
+    void stopMotors();
+
+    void retractTL();
+    void retractTR();
     void retractBL();
+    void retractBR();
+    void retractALL();
+    bool retractingTL = false;
+    bool retractingTR = false;
+    bool retractingBL = false;
+    bool retractingBR = false; 
     
     
     MotorUnit axisTL;
@@ -90,6 +101,7 @@ class Maslow_ {
     //Used to keep track of how often the PID controller is updated
     unsigned long lastCallToPID = millis();
     unsigned long lastMiss = millis();
+    unsigned long lastCallToUpdate = millis();
 
     //Stores a reference to the global system runtime function to be called when blocking operations are needed
     void (*_sys_rt)() = nullptr;

--- a/FluidNC/src/Maslow/MotorUnit.cpp
+++ b/FluidNC/src/Maslow/MotorUnit.cpp
@@ -39,11 +39,6 @@ void MotorUnit::zero(){
  *  @brief  Sets the target location
  */
 void MotorUnit::setTarget(double newTarget){
-    // if(abs(newTarget - setpoint) > 1){
-    //     log_info("Step change in target detected on " << _encoderAddress);
-    //     log_info("Old target: " << setpoint);
-    //     log_info("New target: " << newTarget);
-    // }
     setpoint = newTarget;
 }
 
@@ -55,30 +50,10 @@ double MotorUnit::getTarget(){
 }
 
 /*!
- *  @brief  Sets the position of the cable
- */
-int MotorUnit::setPosition(double newPosition){
-    int angleTotal = (newPosition*4096)/_mmPerRevolution;
-    Maslow.I2CMux.setPort(_encoderAddress);
-    encoder.resetCumulativePosition(angleTotal);
-
-    return true;
-}
-
-/*!
  *  @brief  Reads the current position of the axis
  */
 double MotorUnit::getPosition(){
     double positionNow = (mostRecentCumulativeEncoderReading/4096.0)*_mmPerRevolution*-1;
-
-    // if(abs(positionNow - _lastPosition) > 1){
-    //     log_info("Position jump detected on "  << _encoderAddress << " of " << positionNow - _lastPosition);
-    //     int timeElapsed = millis() - lastCallGetPos;
-    //     log_info("Time since last call: " << timeElapsed);
-    // }
-    // lastCallGetPos = millis();
-    // _lastPosition = positionNow;
-
     return positionNow;
 }
 
@@ -90,17 +65,6 @@ double MotorUnit::getCurrent(){
 }
 
 /*!
- *  @brief  Computes and returns the error in the axis positioning
- */
-double MotorUnit::getError(){
-    
-    double errorDist = setpoint - getPosition();
-    
-    return errorDist;
-    
-}
-
-/*!
  *  @brief  Stops the motor
  */
 void MotorUnit::stop(){
@@ -109,23 +73,22 @@ void MotorUnit::stop(){
 
 //---------------------Functions related to maintaining the PID controllers-----------------------------------------
 
-
-
 /*!
  *  @brief  Reads the encoder value and updates it's position and measures the velocity since the last call
  */
-void MotorUnit::updateEncoderPosition(){
+bool MotorUnit::updateEncoderPosition(){
 
-    if( !Maslow.I2CMux.setPort(_encoderAddress) ) return;
+    if( !Maslow.I2CMux.setPort(_encoderAddress) ) return false;
 
     if(encoder.isConnected()){
         mostRecentCumulativeEncoderReading = encoder.getCumulativePosition(); //This updates and returns the encoder value
+        return true;
     }
     else if(millis() - encoderReadFailurePrintTime > 5000){
         encoderReadFailurePrintTime = millis();
         log_info("Encoder read failure on " << _encoderAddress);
     }
-    //protocol_execute_realtime(); //execute everything from FluidNC between encoder reads
+    return false;
 }
 
 /*!
@@ -139,13 +102,6 @@ double MotorUnit::recomputePID(){
 
     return _commandPWM;
 
-}
-
-/*
-*  @brief  Gets the last command PWM
-*/
-double MotorUnit::getCommandPWM(){
-    return _commandPWM;
 }
 
 /*!
@@ -314,3 +270,34 @@ bool MotorUnit::retract(double targetLength){
         }
     }
 }
+
+
+/*!
+ *  @brief  Sets the position of the cable //UNUSED
+ */
+// int MotorUnit::setPosition(double newPosition){
+
+//     int angleTotal = (newPosition*4096)/_mmPerRevolution;
+//     Maslow.I2CMux.setPort(_encoderAddress);
+//     encoder.resetCumulativePosition(angleTotal);
+
+//     return true;
+// }
+
+// /*
+// *  @brief  Gets the last command PWM // UNUSED
+// */
+// double MotorUnit::getCommandPWM(){
+//     return _commandPWM;
+// }
+
+/*!
+ *  @brief  Computes and returns the error in the axis positioning //UNUSED
+ */
+// double MotorUnit::getError(){
+    
+//     double errorDist = setpoint - getPosition();
+    
+//     return errorDist;
+    
+// }

--- a/FluidNC/src/Maslow/MotorUnit.cpp
+++ b/FluidNC/src/Maslow/MotorUnit.cpp
@@ -122,6 +122,7 @@ void MotorUnit::reset(){
     incrementalThresholdHits = 0;
     amtToMove = 0.1;
     lastPosition = getPosition();
+    beltSpeedTimer = millis();
 }
 /*!
  *  @brief  Sets the motor to comply with how it is being pulled, non-blocking. 
@@ -202,7 +203,7 @@ bool MotorUnit::retract(){
         //EXPERIMENTAL, added because my BR current sensor is faulty, but might be an OK precaution
         //monitor the position change speed  
         bool beltStalled = false;
-        if(retract_speed > 350 && (beltSpeedCounter++ % 10 == 0) ){ // skip the start, might create problems if the belt is slackking a lot
+        if(retract_speed > 450 && (beltSpeedCounter++ % 10 == 0) ){ // skip the start, might create problems if the belt is slackking a lot
             beltSpeed = (getPosition() - lastPosition)*100 / (millis() - beltSpeedTimer);
             beltSpeedTimer = millis();
             lastPosition = getPosition();

--- a/FluidNC/src/Maslow/MotorUnit.cpp
+++ b/FluidNC/src/Maslow/MotorUnit.cpp
@@ -270,34 +270,3 @@ bool MotorUnit::retract(double targetLength){
         }
     }
 }
-
-
-/*!
- *  @brief  Sets the position of the cable //UNUSED
- */
-// int MotorUnit::setPosition(double newPosition){
-
-//     int angleTotal = (newPosition*4096)/_mmPerRevolution;
-//     Maslow.I2CMux.setPort(_encoderAddress);
-//     encoder.resetCumulativePosition(angleTotal);
-
-//     return true;
-// }
-
-// /*
-// *  @brief  Gets the last command PWM // UNUSED
-// */
-// double MotorUnit::getCommandPWM(){
-//     return _commandPWM;
-// }
-
-/*!
- *  @brief  Computes and returns the error in the axis positioning //UNUSED
- */
-// double MotorUnit::getError(){
-    
-//     double errorDist = setpoint - getPosition();
-    
-//     return errorDist;
-    
-// }

--- a/FluidNC/src/Maslow/MotorUnit.h
+++ b/FluidNC/src/Maslow/MotorUnit.h
@@ -17,7 +17,6 @@ class MotorUnit {
                int encoderAddress,
                int channel1,
                int channel2);
-    //void readEncoder();
     void zero();
     void setTarget(double newTarget);
     double getTarget();
@@ -29,9 +28,6 @@ class MotorUnit {
     void decompressBelt();
     bool comply(unsigned long *timeLastMoved, double *lastPosition, double *amtToMove, double maxSpeed);
     bool retract(double targetLength);
-    //double getCommandPWM();
-    //double getError();
-    //int setPosition(double newPosition);
 
 
   private:

--- a/FluidNC/src/Maslow/MotorUnit.h
+++ b/FluidNC/src/Maslow/MotorUnit.h
@@ -21,17 +21,17 @@ class MotorUnit {
     void zero();
     void setTarget(double newTarget);
     double getTarget();
-    int setPosition(double newPosition);
     double getPosition();
     double getCurrent();
-    double getError();
     void stop();
-    void updateEncoderPosition();
+    bool updateEncoderPosition();
     double recomputePID();
     void decompressBelt();
     bool comply(unsigned long *timeLastMoved, double *lastPosition, double *amtToMove, double maxSpeed);
     bool retract(double targetLength);
-    double getCommandPWM();
+    //double getCommandPWM();
+    //double getError();
+    //int setPosition(double newPosition);
 
 
   private:

--- a/FluidNC/src/Maslow/MotorUnit.h
+++ b/FluidNC/src/Maslow/MotorUnit.h
@@ -63,6 +63,10 @@ class MotorUnit {
     double  lastPosition  = getPosition();
     double  amtToMove     = 0.1;
 
+    double beltSpeed = 0;
+    unsigned long beltSpeedTimer = millis();
+    int beltSpeedCounter = 0;
+
 };
 
 #endif

--- a/FluidNC/src/Maslow/MotorUnit.h
+++ b/FluidNC/src/Maslow/MotorUnit.h
@@ -27,7 +27,7 @@ class MotorUnit {
     double recomputePID();
     void decompressBelt();
     bool comply(unsigned long *timeLastMoved, double *lastPosition, double *amtToMove, double maxSpeed);
-    bool retract(double targetLength);
+    bool retract();
 
 
   private:
@@ -46,6 +46,12 @@ class MotorUnit {
     double mostRecentCumulativeEncoderReading = 0;
     double encoderReadFailurePrintTime = millis();
     unsigned long lastCallGetPos = millis();
+
+    int absoluteCurrentThreshold = 1900;
+    int incrementalThreshold = 75;
+    int incrementalThresholdHits = 0;
+    float alpha = .2;
+    
     
 
 };

--- a/FluidNC/src/Maslow/MotorUnit.h
+++ b/FluidNC/src/Maslow/MotorUnit.h
@@ -26,8 +26,11 @@ class MotorUnit {
     bool updateEncoderPosition();
     double recomputePID();
     void decompressBelt();
-    bool comply(unsigned long *timeLastMoved, double *lastPosition, double *amtToMove, double maxSpeed);
+    bool comply(double maxSpeed);
     bool retract();
+    bool extend(double targetLength);
+
+    void reset(); //resetting variables here, because of non-blocking, maybe there's a better way to do this
 
 
   private:
@@ -47,12 +50,18 @@ class MotorUnit {
     double encoderReadFailurePrintTime = millis();
     unsigned long lastCallGetPos = millis();
 
+    //retract variables
     int absoluteCurrentThreshold = 1900;
     int incrementalThreshold = 75;
     int incrementalThresholdHits = 0;
     float alpha = .2;
-    
-    
+    uint16_t retract_speed = 0;
+    float retract_baseline = 700;
+
+    //comply variables
+    unsigned long lastCallToComply = millis();
+    double  lastPosition  = getPosition();
+    double  amtToMove     = 0.1;
 
 };
 

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -929,10 +929,10 @@ void make_user_commands() {
     new UserCommand("TR", "TopRightRetract", maslow_retract_TR, anyState);
     new UserCommand("BR", "BottomRightRetract", maslow_retract_BR, anyState);
     new UserCommand("BL", "BottomLeftRetract", maslow_retract_BL, anyState);
-    new UserCommand("ALL", "retractALL", maslow_retract_ALL, notIdleOrAlarm);
-    new UserCommand("EXT", "extendALL", maslow_extend_ALL, notIdleOrAlarm);
-    new UserCommand("CMP", "comply", maslow_set_comply, notIdleOrAlarm);
-    new UserCommand("ST", "STOP", maslow_stop, anyState); // experimental
+    new UserCommand("ALL", "retractALL", maslow_retract_ALL, anyState);
+    new UserCommand("EXT", "extendALL", maslow_extend_ALL, anyState);
+    new UserCommand("CMP", "comply", maslow_set_comply, anyState);
+    new UserCommand("STP", "STOP", maslow_stop, anyState); // experimental
 
 };
 

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -23,6 +23,7 @@
 #include "xmodem.h"               // xmodemReceive(), xmodemTransmit()
 #include "StartupLog.h"           // startupLog
 #include "Driver/fluidnc_gpio.h"  // gpio_dump()
+#include "Maslow/Maslow.h"
 
 #include "FluidPath.h"
 
@@ -818,7 +819,33 @@ static Error showHeap(const char* value, WebUI::AuthenticationLevel auth_level, 
     log_info("Heap free: " << xPortGetFreeHeapSize() << " min: " << heapLowWater);
     return Error::Ok;
 }
-
+//Maslow-specific user functions
+static Error maslow_retract_TL(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+    sys.set_state(State::Homing);
+    Maslow.retractTL();
+    return Error::Ok;
+}
+static Error maslow_retract_TR(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+    sys.set_state(State::Homing);
+    Maslow.retractTR();
+    return Error::Ok;
+}
+static Error maslow_retract_BR(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+    sys.set_state(State::Homing);
+    Maslow.retractBR();
+    return Error::Ok;
+}
+static Error maslow_retract_BL(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+    sys.set_state(State::Homing);
+    Maslow.retractBL();
+    return Error::Ok;
+}
+static Error maslow_retract_ALL(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+    sys.set_state(State::Homing);
+    log_info("Retracting all belts");
+    Maslow.retractALL();
+    return Error::Ok;
+}
 // Commands use the same syntax as Settings, but instead of setting or
 // displaying a persistent value, a command causes some action to occur.
 // That action could be anything, from displaying a run-time parameter
@@ -880,6 +907,13 @@ void make_user_commands() {
 
     new UserCommand("30", "FakeMaxSpindleSpeed", fakeMaxSpindleSpeed, notIdleOrAlarm);
     new UserCommand("32", "FakeLaserMode", fakeLaserMode, notIdleOrAlarm);
+    //Maslow-specific commands
+    new UserCommand("TL", "TopLeftRetract", maslow_retract_TL, notIdleOrAlarm);
+    new UserCommand("TR", "TopRightRetract", maslow_retract_TR, notIdleOrAlarm);
+    new UserCommand("BR", "BottomRightRetract", maslow_retract_BR, notIdleOrAlarm);
+    new UserCommand("BL", "BottomLeftRetract", maslow_retract_BL, notIdleOrAlarm);
+    new UserCommand("ALL", "retractALL", maslow_retract_ALL, notIdleOrAlarm);
+
 };
 
 // normalize_key puts a key string into canonical form -

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -854,7 +854,7 @@ static Error maslow_extend_ALL(const char* value, WebUI::AuthenticationLevel aut
 }
 static Error maslow_stop(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
     sys.set_state(State::Alarm);
-    Maslow.stopMotors();
+    Maslow.stop();
     return Error::Ok;
 }
 static Error maslow_set_comply(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -846,6 +846,23 @@ static Error maslow_retract_ALL(const char* value, WebUI::AuthenticationLevel au
     Maslow.retractALL();
     return Error::Ok;
 }
+static Error maslow_extend_ALL(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+    sys.set_state(State::Homing);
+    log_info("Extending all belts");
+    Maslow.extendALL();
+    return Error::Ok;
+}
+static Error maslow_stop(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+    sys.set_state(State::Alarm);
+    Maslow.stopMotors();
+    return Error::Ok;
+}
+static Error maslow_set_comply(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+    sys.set_state(State::Homing);
+    log_info("Set to comply");
+    Maslow.comply();
+    return Error::Ok;
+}
 // Commands use the same syntax as Settings, but instead of setting or
 // displaying a persistent value, a command causes some action to occur.
 // That action could be anything, from displaying a run-time parameter
@@ -908,11 +925,14 @@ void make_user_commands() {
     new UserCommand("30", "FakeMaxSpindleSpeed", fakeMaxSpindleSpeed, notIdleOrAlarm);
     new UserCommand("32", "FakeLaserMode", fakeLaserMode, notIdleOrAlarm);
     //Maslow-specific commands
-    new UserCommand("TL", "TopLeftRetract", maslow_retract_TL, notIdleOrAlarm);
-    new UserCommand("TR", "TopRightRetract", maslow_retract_TR, notIdleOrAlarm);
-    new UserCommand("BR", "BottomRightRetract", maslow_retract_BR, notIdleOrAlarm);
-    new UserCommand("BL", "BottomLeftRetract", maslow_retract_BL, notIdleOrAlarm);
+    new UserCommand("TL", "TopLeftRetract", maslow_retract_TL, anyState);
+    new UserCommand("TR", "TopRightRetract", maslow_retract_TR, anyState);
+    new UserCommand("BR", "BottomRightRetract", maslow_retract_BR, anyState);
+    new UserCommand("BL", "BottomLeftRetract", maslow_retract_BL, anyState);
     new UserCommand("ALL", "retractALL", maslow_retract_ALL, notIdleOrAlarm);
+    new UserCommand("EXT", "extendALL", maslow_extend_ALL, notIdleOrAlarm);
+    new UserCommand("CMP", "comply", maslow_set_comply, notIdleOrAlarm);
+    new UserCommand("ST", "STOP", maslow_stop, anyState); // experimental
 
 };
 

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -835,10 +835,7 @@ void protocol_exec_rt_system() {
 
     
     //do all the Maslow stuff here
-    if(!Maslow.using_default_config && ( sys.state() == State::Jog || sys.state() == State::Cycle ) ){
-        Maslow.setTargets(steps_to_mpos(get_axis_motor_steps(0),0), steps_to_mpos(get_axis_motor_steps(1),1), steps_to_mpos(get_axis_motor_steps(2),2));
-        Maslow.recomputePID();
-    }
+    Maslow.update();
     // Reload step segment buffer
     switch (sys.state()) {
         case State::ConfigAlarm:


### PR DESCRIPTION
new user commands:
$TL, $TR, $BR, $BL - retract belts
$ALL - retract all
$CMP - comply mode
$EXT - extend all belts
$STP - stop everything and get back to idle
index.html is unchanged in this commit
Calibration is disabled, and not called from anywhere. G-code execution seems to work, but hasn't been tested extensively (due to upcoming changes that are supposed to make tests safer) 