### PR TITLE
Calibration running

### DIFF
--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -490,7 +490,6 @@ void Maslow_::reset_all_axis(){
 }
 // move pulling just two belts depending on the direction of the movement
 bool Maslow_::move_with_slack(double fromX, double fromY, double toX, double toY) {
-  //setTargets(toX,toY, 0); //OK so we are going full speed to the target position which seems like it could be causing issues
   
   //How big of steps do we want to take with each loop?
   double stepSize = 0.01;
@@ -502,10 +501,8 @@ bool Maslow_::move_with_slack(double fromX, double fromY, double toX, double toY
   int xDirection = currentXTarget - toX > 0 ? -1 : 1;
   int yDirection = currentYTarget - toY > 0 ? -1 : 1;
 
-  setTargets(currentXTarget + xDirection * stepSize, currentYTarget + yDirection * stepSize, 0);
+  setTargets(currentXTarget + xDirection * stepSize, currentYTarget + yDirection * stepSize, 0, true, true, false, false);
 
-//   log_info("xDirection " << xDirection << " yDirection " << yDirection); //We are hoping for xDirection -1 yDirection 1
-  //log_info("currentXTarget " << currentXTarget << " currentYTarget " << currentYTarget);
 
   //Move set the belt's target lengths to be closer to where we want to be
   int direction  = get_direction(fromX, fromY, toX, toY);
@@ -1069,7 +1066,7 @@ float Maslow_::computeTL(float x, float y, float z){
 * This computes the target lengths of the belts based on the target x and y coordinates
 * and sends that information to each arm.
 */
-void Maslow_::setTargets(float xTarget, float yTarget, float zTarget){
+void Maslow_::setTargets(float xTarget, float yTarget, float zTarget, bool tl, bool tr, bool bl, bool br){
 
         //Store the target x and y coordinates for the getTargetN() functions
         targetX = xTarget;
@@ -1078,10 +1075,18 @@ void Maslow_::setTargets(float xTarget, float yTarget, float zTarget){
 
         computeTensions(xTarget, yTarget);
 
-        axisBL.setTarget(computeBL(xTarget, yTarget, zTarget));
-        axisBR.setTarget(computeBR(xTarget, yTarget, zTarget));
-        axisTR.setTarget(computeTR(xTarget, yTarget, zTarget));
-        axisTL.setTarget(computeTL(xTarget, yTarget, zTarget));
+        if(tl){
+            axisTL.setTarget(computeTL(xTarget, yTarget, zTarget));
+        }
+        if(tr){
+            axisTR.setTarget(computeTR(xTarget, yTarget, zTarget));
+        }
+        if(bl){
+            axisBL.setTarget(computeBL(xTarget, yTarget, zTarget));
+        }
+        if(br){
+            axisBR.setTarget(computeBR(xTarget, yTarget, zTarget));
+        }
 }
 
 /*

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -514,7 +514,7 @@ bool Maslow_::move_with_slack(double fromX, double fromY, double toX, double toY
         axisTR.recomputePID();
         axisBL.comply(comply_spd);
         axisBR.comply(comply_spd);
-        if( axisTL.onTarget(0.1) && axisTR.onTarget(0.1) ) {
+        if( axisTL.onTarget(0.5) && axisTR.onTarget(0.5) ) {
             log_info("Moving with slack hit target and finsihed up");
             stopMotors();
             reset_all_axis();
@@ -655,7 +655,6 @@ void Maslow_::update(){
         //quick solution for delay without blocking
         if(holding && millis() - holdTimer > holdTime){
             holding = false;
-            //log_info("Done holding" << int( millis() - holdTimer) << "ms");
         }
         else if (holding) return;
 
@@ -678,12 +677,20 @@ void Maslow_::update(){
             home();
 
         }
+        else { //In any other state, keep motors off
+        
+        
+        digitalWrite(coolingFanPin, HIGH);
+        //We need to fix the cooling fan turning on at the right times. I think that we want it on any time any motor is moving
+        // if(sys.state() != State::Idle){
+        //     digitalWrite(coolingFanPin, HIGH);  //keep the cooling fan on
+        // }
+        // else {
+        //     digitalWrite(coolingFanPin, LOW);  //Turn the cooling fan off
+        // }
 
-        //In any other state, keep motors off
-        else {
-            
         if(!test) Maslow.stopMotors();
-
+ 
         }
 
         //if the update function is not being called enough, stop everything to prevent damage
@@ -914,7 +921,7 @@ void Maslow_::recomputePID(){
     axisTL.recomputePID();
     digitalWrite(coolingFanPin, HIGH);  //keep the cooling fan on
 
-    if (digitalRead(SERVOFAULT) == 1) { //no idea what this does, so I'm keeping it
+    if (digitalRead(SERVOFAULT) == 1) { //The servo drives have a fault pin that goes high when there is a fault (ie one over heats). We should probably call panic here. Also this should probably be read in the main loop
         log_info("Servo fault!");
     }
 }

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -123,7 +123,7 @@ void Maslow_::begin(void (*sys_rt)()) {
 
   pinMode(SERVOFAULT, INPUT);
 
-  currentThreshold = 1500;
+  currentThreshold = 1700;
   lastCallToUpdate = millis();
   orientation = VERTICAL;
   log_info("Starting Maslow v 1.00");
@@ -508,6 +508,8 @@ bool Maslow_::onTarget(double targetX, double targetY, double currentX, double c
 // move pulling just two belts depending on the direction of the movement
 bool Maslow_::move_with_slack(double fromX, double fromY, double toX, double toY) {
   
+  //This is where we want to introduce some slack so the system
+
   //How big of steps do we want to take with each loop?
   double stepSize = 0.01;
 
@@ -775,6 +777,13 @@ void Maslow_::retractALL(){
 }
 void Maslow_::extendALL(){
     // ADD also shouldn't extend before we get the parameters from the user
+
+    if(!all_axis_homed()){
+        log_error("Cannot extend all until all axis are homed"); //I keep getting everything set up for calibration and then this trips me up
+        sys.set_state(State::Idle);
+        return;
+    }
+
     stop();
     extendingALL = true;
     log_info("Extending All");
@@ -1033,7 +1042,7 @@ float Maslow_::computeBL(float x, float y, float z){
 
     //Add some extra slack if this belt isn't needed because the upper belt is already very taught
     //Max tension is around -1.81 at the very top and -.94 at the bottom
-    float extraSlack = min(max(-34.48*trTension - 32.41, 0.0), 8.0); //limit of 0-2mm of extension
+    //float extraSlack = min(max(-34.48*trTension - 32.41, 0.0), 8.0); //limit of 0-2mm of extension
 
     return length + lowerBeltsExtra;
 }
@@ -1049,7 +1058,7 @@ float Maslow_::computeBR(float x, float y, float z){
 
     float length = sqrt(a*a+b*b+c*c) - (_beltEndExtension+_armLength);
 
-    float extraSlack = min(max(-34.48*tlTension - 32.41, 0.0), 8.0); //limit of 0-2mm of extension
+    //float extraSlack = min(max(-34.48*tlTension - 32.41, 0.0), 8.0); //limit of 0-2mm of extension
 
     // if(random(4000) == 10){
     //     grbl_sendf( "BR Slack By: %f\n", extraSlack);

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -392,7 +392,7 @@ void Maslow_::calibration_loop(){
                 measurementInProgress = false;
                 waypoint++;
 
-                if(waypoint > 99){
+                if(waypoint > 98 ){
                     calibrationInProgress = false;
                     waypoint = 0;
                     log_info("Calibration complete");
@@ -460,23 +460,32 @@ void Maslow_::hold(unsigned long time){
     holdTimer = millis();
     //log_info("Holding for " << int(time) << "ms");
 }
+
 void Maslow_::generate_calibration_grid() {
-  //generate calibration grid 10x10 between top left and bottom right corners with offset of CALIBRATION_GRID_OFFSET
-  double xStep     = (brX - tlX - 2 * CALIBRATION_GRID_OFFSET) / 10;
-  double yStep     = (tlY - brY - 2 * CALIBRATION_GRID_OFFSET) / 10;
-  bool   moveRight = true;  // flag to alternate direction
-  for (int i = 0; i < 100; i++) {
-      int row = i / 10;
-      int col = i % 10;
-      if (moveRight) {
-            calibrationGrid[i][0] =  (CALIBRATION_GRID_OFFSET + col * xStep ) - centerX;  // x coord
-      } else {
-            calibrationGrid[i][0] =  (CALIBRATION_GRID_OFFSET + ((9 - col) * xStep)) - centerX;  // x coord
+  log_info("Generating calibration grid");
+
+  int gridSizeX = 10;
+  int gridSizeY = 9;
+  int xSpacing = 175;
+  int ySpacing = 100;
+  int pointCount = 0;
+
+  for(int i = -gridSizeX/2; i <= gridSizeX/2; i++) {
+    if(i % 2 == 0) {
+      for(int j = -gridSizeY/2; j <= gridSizeY/2; j++) {
+        log_info("Point: " << pointCount << "(" << i * xSpacing << ", " << j * ySpacing << ")");
+        calibrationGrid[pointCount][0] = i * xSpacing;
+        calibrationGrid[pointCount][1] = j * ySpacing;
+        pointCount++;
       }
-      calibrationGrid[i][1] =  (CALIBRATION_GRID_OFFSET + ((9 - row) * yStep) ) - centerY ;  // y coord
-      if (col == 9) {                                                       // reached end of row
-            moveRight = !moveRight;                                         // alternate direction
+    } else {
+      for(int j = gridSizeY/2; j >= -gridSizeY/2; j--) {
+        log_info("Point: " << pointCount << "(" << i * xSpacing << ", " << j * ySpacing << ")"); 
+        calibrationGrid[pointCount][0] = i * xSpacing;
+        calibrationGrid[pointCount][1] = j * ySpacing;
+        pointCount++;
       }
+    }
   }
 }
 

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -574,8 +574,8 @@ void Maslow_::safety_control() {
   MotorUnit* axis[4] = { &axisTL, &axisTR, &axisBL, &axisBR };
   for (int i = 0; i < 4; i++) {
       //If the current exceeds some absolute value, we need to call panic() and stop the machine
-      if (axis[i]->getMotorCurrent() > currentThreshold+2200  && !tick[i]) {
-          log_error("Motor current on " << axis_id_to_label(i).c_str() << " axis exceeded threshold of " << currentThreshold+2200
+      if (axis[i]->getMotorCurrent() > currentThreshold+220000  && !tick[i]) {
+          log_error("Motor current on " << axis_id_to_label(i).c_str() << " axis exceeded threshold of " << currentThreshold+220000
                                         << "mA, current is " << int(axis[i]->getMotorCurrent()) << "mA");
           Maslow.panic();
           tick[i] = true;

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -342,8 +342,8 @@ bool Maslow_::take_measurement_avg_with_check(int waypoint) {
                     }
               }
               //reset the run counter to run the measurements again
-              if (criticalCounter++ > 2) {
-                    log_error("Critical error, measurements are not within 1.5mm of each other 3 times in a row, stopping calibration");
+              if (criticalCounter++ > 8) {
+                    log_error("Critical error, measurements are not within 1.5mm of each other 8 times in a row, stopping calibration");
                     calibrationInProgress = false;
                     waypoint              = 0;
                     criticalCounter       = 0;
@@ -496,6 +496,15 @@ void Maslow_::reset_all_axis(){
     axisBL.reset();
     axisBR.reset();
 }
+
+//Checks to see how close we are to the targetX and targetY position. If we are within the tolerance, we are on target and return true;
+bool Maslow_::onTarget(double targetX, double targetY, double currentX, double currentY, double tolerance) {
+  if (abs(targetX - currentX) < tolerance && abs(targetY - currentY) < tolerance) {
+    return true;
+  }
+  return false;
+}
+
 // move pulling just two belts depending on the direction of the movement
 bool Maslow_::move_with_slack(double fromX, double fromY, double toX, double toY) {
   
@@ -520,7 +529,7 @@ bool Maslow_::move_with_slack(double fromX, double fromY, double toX, double toY
         axisTR.recomputePID();
         axisBL.comply(comply_spd);
         axisBR.comply(comply_spd);
-        if( axisTL.onTarget(0.5) && axisTR.onTarget(0.5) ) {
+        if( onTarget(toX, toY, getTargetX(), getTargetY(), 0.5) ) {
             stopMotors();
             reset_all_axis();
             return true;

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -503,8 +503,6 @@ bool Maslow_::move_with_slack(double fromX, double fromY, double toX, double toY
 
   setTargets(currentXTarget + xDirection * stepSize, currentYTarget + yDirection * stepSize, 0, true, true, false, false);
 
-
-  //Move set the belt's target lengths to be closer to where we want to be
   int direction  = get_direction(fromX, fromY, toX, toY);
   int comply_spd = 1500;
   
@@ -515,7 +513,6 @@ bool Maslow_::move_with_slack(double fromX, double fromY, double toX, double toY
         axisBL.comply(comply_spd);
         axisBR.comply(comply_spd);
         if( axisTL.onTarget(0.5) && axisTR.onTarget(0.5) ) {
-            log_info("Moving with slack hit target and finsihed up");
             stopMotors();
             reset_all_axis();
             return true;
@@ -527,7 +524,6 @@ bool Maslow_::move_with_slack(double fromX, double fromY, double toX, double toY
             axisBL.recomputePID();
             axisBR.recomputePID();
             if( axisBL.onTarget(0.5) && axisBR.onTarget(0.5) ) {
-                log_info("Moving with slack hit target and finsihed down");
                 stopMotors();
                 reset_all_axis();
                 return true;
@@ -539,7 +535,6 @@ bool Maslow_::move_with_slack(double fromX, double fromY, double toX, double toY
             axisBL.recomputePID();
             axisBR.comply(comply_spd);
             if( axisTL.onTarget(0.5) && axisBL.onTarget(0.5) ) {
-                log_info("Moving with slack hit target and finsihed left");
                 stopMotors();
                 reset_all_axis();
                 return true;
@@ -551,7 +546,6 @@ bool Maslow_::move_with_slack(double fromX, double fromY, double toX, double toY
             axisBL.comply(comply_spd);
             axisBR.recomputePID();
             if( axisTR.onTarget(0.5) && axisBR.onTarget(0.5) ) {
-                log_info("Moving with slack hit target and finsihed right");
                 stopMotors();
                 reset_all_axis();
                 return true;                

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -299,7 +299,6 @@ bool Maslow_::take_measurement_avg_with_check(int waypoint) {
 //   }
 
   if (take_measurement(waypoint)) {
-      //log_info("Took measurement at run " << run);
       if (run < 3) {
           //decompress lower belts for 500 ms before taking the next measurement
           decompressTimer = millis();
@@ -402,7 +401,7 @@ void Maslow_::calibration_loop(){
                 }
                 else{
                     log_info("Moving from: " << calibrationGrid[waypoint-1][0] << " " << calibrationGrid[waypoint-1][1] << " to: " << calibrationGrid[waypoint][0] << " " << calibrationGrid[waypoint][1] << " direction: " << get_direction(calibrationGrid[waypoint-1][0], calibrationGrid[waypoint-1][1], calibrationGrid[waypoint][0], calibrationGrid[waypoint][1]));
-                    setTargets(calibrationGrid[waypoint][0], calibrationGrid[waypoint][1], 0);
+                    move_with_slack(getTargetX(), getTargetY(), calibrationGrid[waypoint][0], calibrationGrid[waypoint][1]);
                 }
             }
         }

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -3,10 +3,10 @@
 #include "../Report.h"
 
 // Maslow specific defines
-#define TLEncoderLine 0
-#define TREncoderLine 2
-#define BLEncoderLine 1
-#define BREncoderLine 3
+#define TLEncoderLine 2
+#define TREncoderLine 1
+#define BLEncoderLine 3
+#define BREncoderLine 0
 
 #define motorPWMFreq 2000
 #define motorPWMRes 10
@@ -78,31 +78,31 @@ void Maslow_::begin(void (*sys_rt)()) {
   axisTRHomed = false;
   axisTLHomed = false;
 
-//   tlX =-3.127880538461895;
-//   tlY = 2063.1006937512166;
-//   tlZ = 116 + 38;
-//   trX = 2944.4878198392585; 
-//   trY = 2069.656171241167;
-//   trZ = 69 + 38;
-//   blX = 0;
-//   blY = 0;
-//   blZ = 47 + 38;
-//   brX = 2959.4124827780993;
-//   brY = 0;
-//   brZ = 89 + 38;
-
-  tlX = 5.5;
-  tlY = 2150;
-  tlZ = 0;
-  trX = 3135; 
-  trY = 2150;
-  trZ = 0;
+  tlX =-3.127880538461895;
+  tlY = 2063.1006937512166;
+  tlZ = 116 + 38;
+  trX = 2944.4878198392585; 
+  trY = 2069.656171241167;
+  trZ = 69 + 38;
   blX = 0;
   blY = 0;
-  blZ = 0;
-  brX = 3095;
+  blZ = 47 + 38;
+  brX = 2959.4124827780993;
   brY = 0;
-  brZ = 0;
+  brZ = 89 + 38;
+
+//   tlX = 5.5;
+//   tlY = 2150;
+//   tlZ = 0;
+//   trX = 3135; 
+//   trY = 2150;
+//   trZ = 0;
+//   blX = 0;
+//   blY = 0;
+//   blZ = 0;
+//   brX = 3095;
+//   brY = 0;
+//   brZ = 0;
 
 
   tlTension = 0;

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -114,7 +114,6 @@ class Maslow_ {
     int frame_dimention_MIN = 1000;
     int frame_dimention_MAX = 5000;
 
-    double CALIBRATION_GRID_OFFSET = 750; // distance from the corner in x and y directions
     double calibrationGrid[100][2] = {0};
 
     void generate_calibration_grid();

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -25,6 +25,9 @@ class Maslow_ {
     void update();
     bool updateEncoderPositions();
     void setTargets(float xTarget, float yTarget, float zTarget);
+    double getTargetX();
+    double getTargetY();
+    double getTargetZ();
     void recomputePID();
 
     //math 
@@ -82,6 +85,10 @@ class Maslow_ {
     bool complyALL = false;
 
     bool safetyOn = true;
+
+    double targetX = 0;
+    double targetY = 0;
+    double targetZ = 0;
     
     
     MotorUnit axisTL;

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -117,6 +117,7 @@ class Maslow_ {
     double calibrationGrid[100][2] = {0};
 
     void generate_calibration_grid();
+    bool onTarget(double targetX, double targetY, double currentX, double currentY, double tolerance);
     bool move_with_slack(double fromX, double fromY, double toX, double toY);
     int get_direction(double x, double y, double targetX, double targetY);
     bool take_measurement_avg_with_check(int waypoint);

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -24,7 +24,7 @@ class Maslow_ {
     void home();
     void update();
     bool updateEncoderPositions();
-    void setTargets(float xTarget, float yTarget, float zTarget);
+    void setTargets(float xTarget, float yTarget, float zTarget, bool tl = true, bool tr = true, bool bl = true, bool br = true);
     double getTargetX();
     double getTargetY();
     double getTargetZ();

--- a/FluidNC/src/Maslow/MotorUnit.cpp
+++ b/FluidNC/src/Maslow/MotorUnit.cpp
@@ -205,10 +205,6 @@ bool MotorUnit::comply( double maxSpeed){
     float positionNow = getPosition();
     float distMoved = positionNow - lastPosition;
 
-    if(_encoderAddress == 0 && random(10) == 0){
-        log_info("BR complying. Dist moved: " << distMoved << "amtToMove: " << amtToMove);
-    }
-
     //If the belt is moving out, let's keep it moving out
     if( distMoved > .001){
         //Increment the target

--- a/FluidNC/src/Maslow/MotorUnit.cpp
+++ b/FluidNC/src/Maslow/MotorUnit.cpp
@@ -205,6 +205,10 @@ bool MotorUnit::comply( double maxSpeed){
     float positionNow = getPosition();
     float distMoved = positionNow - lastPosition;
 
+    if(_encoderAddress == 0 && random(10) == 0){
+        log_info("BR complying. Dist moved: " << distMoved << "amtToMove: " << amtToMove);
+    }
+
     //If the belt is moving out, let's keep it moving out
     if( distMoved > .001){
         //Increment the target
@@ -230,8 +234,8 @@ bool MotorUnit::comply( double maxSpeed){
 
     lastPosition = positionNow;
 
-        lastCallToComply = millis();
-        return true;
+    lastCallToComply = millis();
+    return true;
 }
 
 /*!

--- a/FluidNC/src/Maslow/MotorUnit.cpp
+++ b/FluidNC/src/Maslow/MotorUnit.cpp
@@ -194,7 +194,6 @@ return false;
  *  @brief  Sets the motor to comply with how it is being pulled, non-blocking. 
  */
 bool MotorUnit::comply( double maxSpeed){
-
     //Call it every 25 ms
     if(millis() - lastCallToComply < 25){
         return true;

--- a/FluidNC/src/Maslow/MotorUnit.h
+++ b/FluidNC/src/Maslow/MotorUnit.h
@@ -64,7 +64,7 @@ class MotorUnit {
     unsigned long motorCurrentTimer = millis();
 
     //retract variables
-    int absoluteCurrentThreshold = 1700;
+    int absoluteCurrentThreshold = 1900;
     int incrementalThreshold = 125;
     int incrementalThresholdHits = 0;
     float alpha = .2;

--- a/platformio.ini
+++ b/platformio.ini
@@ -148,7 +148,7 @@ extends = common_esp32_s3
 lib_deps = ${common.lib_deps} ${common.wifi_deps}
 build_flags = ${common_esp32.build_flags}  ${common_wifi.build_flags} -DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=1
 upload_protocol = espota
-upload_port = 192.168.1.9 #192.168.0.1
+upload_port = 192.168.0.1
 
 [env:bt_s3]
 extends = common_esp32_s3

--- a/platformio.ini
+++ b/platformio.ini
@@ -148,7 +148,7 @@ extends = common_esp32_s3
 lib_deps = ${common.lib_deps} ${common.wifi_deps}
 build_flags = ${common_esp32.build_flags}  ${common_wifi.build_flags} -DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=1
 upload_protocol = espota
-upload_port = 192.168.0.1
+upload_port = 192.168.1.151
 
 [env:bt_s3]
 extends = common_esp32_s3


### PR DESCRIPTION
That bug turned out to be pretty tricky. What it ended up being was that the `setTargets()` function was getting called in the main `move_with_slack()` function on all four arms, and then also being called again on the lower arms in `comply()`. Because `comply()` has a constraint that let's it only run at most once every 25ms there was this sort of weird ailising effect where depending on the timing of how other bits of code ran it could work or not work.