### PR TITLE
Set current threshold back down

### DIFF
--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -129,7 +129,7 @@ void Maslow_::begin(void (*sys_rt)()) {
 
   pinMode(SERVOFAULT, INPUT);
 
-  currentThreshold = 1700;
+  currentThreshold = 1500;
   lastCallToUpdate = millis();
   orientation = VERTICAL;
   log_info("Starting Maslow v 1.00");

--- a/FluidNC/src/Maslow/MotorUnit.cpp
+++ b/FluidNC/src/Maslow/MotorUnit.cpp
@@ -284,7 +284,6 @@ bool MotorUnit::retract(){
         else{
             return false;
         }
-            
 }
 // extends the belt to the target length until it hits the target length, returns true when target length is reached
 bool MotorUnit::extend(double targetLength) {

--- a/FluidNC/src/Maslow/MotorUnit.h
+++ b/FluidNC/src/Maslow/MotorUnit.h
@@ -64,7 +64,7 @@ class MotorUnit {
     unsigned long motorCurrentTimer = millis();
 
     //retract variables
-    int absoluteCurrentThreshold = 1900;
+    int absoluteCurrentThreshold = 1500;
     int incrementalThreshold = 125;
     int incrementalThresholdHits = 0;
     float alpha = .2;


### PR DESCRIPTION
I thought this was the current limit for retracting, but it's actually for calibration so I shouldn't have changed it