### PR TITLE
Remove incorrect pins from config file

### DIFF
--- a/FluidNC/data/maslow.yaml
+++ b/FluidNC/data/maslow.yaml
@@ -64,7 +64,6 @@ axes:
         use_enable: true
         direction_pin: gpio.16
         step_pin: gpio.15
-        disable_pin: gpio.17
     
     motor1:
       tmc_2209:
@@ -83,5 +82,5 @@ axes:
         run_mode: StealthChop
         homing_mode: StealthChop
         use_enable: true
-        direction_pin: gpio.35
+        direction_pin: gpio.38
         step_pin: gpio.46


### PR DESCRIPTION
This removes incorrect pins from the config file which makes it so that the blue light can be used without it impacting the stepper drivers. We're still using one of the AUX pins so we should talk to the fluidNC folks about how to correctly identify two stepper drivers which share step and direction pins.