### PR TITLE
Allow z-axis to be moved before calibration without the other belts extending 

### DIFF
--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -757,7 +757,11 @@ void Maslow_::update(){
         if( sys.state() == State::Jog || sys.state() == State::Cycle  ){
 
             Maslow.setTargets(steps_to_mpos(get_axis_motor_steps(0),0), steps_to_mpos(get_axis_motor_steps(1),1), steps_to_mpos(get_axis_motor_steps(2),2));
-            Maslow.recomputePID();
+
+            //This allows the z-axis to be moved without the motors being enabled before calibration is run
+            if(all_axis_homed()){
+                Maslow.recomputePID();
+            }
         } else if(sys.state() == State::Homing){ //Homing routines
 
             home();

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -706,27 +706,27 @@ void Maslow_::safety_control() {
 // Maslow main loop
 void Maslow_::update(){
 
-    if(random(1000) == 0){
+    if(random(10000) == 0){
         digitalWrite(ETHERNETLEDPIN, LOW);
     }
     
-    if(random(1000) == 0){
+    if(random(10000) == 0){
         digitalWrite(ETHERNETLEDPIN, HIGH);
     }
 
-    if(random(1000) == 0){
+    if(random(10000) == 0){
         digitalWrite(WIFILED, LOW);
     }
 
-    if(random(1000) == 0){
+    if(random(10000) == 0){
         digitalWrite(WIFILED, HIGH);
     }
 
-    if(random(1000) == 0){
+    if(random(10000) == 0){
         digitalWrite(REDLED, LOW);
     }
 
-    if(random(1000) == 0){
+    if(random(10000) == 0){
         digitalWrite(REDLED, HIGH);
     }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -148,7 +148,7 @@ extends = common_esp32_s3
 lib_deps = ${common.lib_deps} ${common.wifi_deps}
 build_flags = ${common_esp32.build_flags}  ${common_wifi.build_flags} -DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=1
 upload_protocol = espota
-upload_port = 192.168.1.156
+upload_port = 192.168.1.157
 
 [env:bt_s3]
 extends = common_esp32_s3


### PR DESCRIPTION
This is useful for putting the router bit in when the belts are retracted before cutting 