### PR TITLE
Change the default IP address to Maslow.local

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -148,7 +148,7 @@ extends = common_esp32_s3
 lib_deps = ${common.lib_deps} ${common.wifi_deps}
 build_flags = ${common_esp32.build_flags}  ${common_wifi.build_flags} -DARDUINO_USB_MODE=1 -DARDUINO_USB_CDC_ON_BOOT=1
 upload_protocol = espota
-upload_port = 192.168.1.157
+upload_port = maslow.local
 
 [env:bt_s3]
 extends = common_esp32_s3


### PR DESCRIPTION
This changes the default IP address for uploading the firmware to Maslow.local which is going to be right for way more people than whatever random IP address was used last