### PR TITLE
Make the blue LED blink out the machine's IP address 

### DIFF
--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -186,9 +186,10 @@ void Maslow_::blinkIPAddress() {
     static size_t currentChar = 0;
     static int currentBlink = 0;
     static unsigned long lastBlinkTime = 0;
+    static bool inPause = false;
 
-    int shortMS = 300;
-    int longMS = 1000;
+    int shortMS = 400;
+    int longMS = 500;
     int pauseMS = 2000;
 
     std::string IP_String = WebUI::wifi_config.getIP();
@@ -197,22 +198,26 @@ void Maslow_::blinkIPAddress() {
         currentChar = 0;
         currentBlink = 0;
         lastBlinkTime = 0;
+        inPause = false;
         digitalWrite(WIFILED, LOW);
         return;
     }
 
     char c = IP_String[currentChar];
-
     if (isdigit(c)) {
         int blinkCount = c - '0';
         if (currentBlink < blinkCount * 2) {
             if (millis() - lastBlinkTime >= shortMS) {
-                log_info("Blinking Digit: " << c);
+                //log_info("Blinking Digit: " << c);
                 digitalWrite(WIFILED, currentBlink % 2 == 0 ? HIGH : LOW);
                 currentBlink++;
                 lastBlinkTime = millis();
             }
-        } else {
+        } else if (!inPause) {
+            inPause = true;
+            lastBlinkTime = millis();
+        } else if (millis() - lastBlinkTime >= pauseMS) {
+            inPause = false;
             currentChar++;
             currentBlink = 0;
         }

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -35,6 +35,7 @@ class Maslow_ {
     void begin(void (*sys_rt)());
     void home();
     void update();
+    void blinkIPAddress();
     bool updateEncoderPositions();
     void setTargets(float xTarget, float yTarget, float zTarget, bool tl = true, bool tr = true, bool bl = true, bool br = true);
     double getTargetX();

--- a/FluidNC/src/WebUI/WifiConfig.cpp
+++ b/FluidNC/src/WebUI/WifiConfig.cpp
@@ -424,6 +424,15 @@ namespace WebUI {
         return result;
     }
 
+    std::string WiFiConfig::getIP() {
+        std::string result;
+
+        if ((WiFi.getMode() == WIFI_MODE_STA) || (WiFi.getMode() == WIFI_MODE_APSTA)) {
+            result += IP_string(WiFi.localIP());
+        }
+        return result;
+    }
+
     std::string WiFiConfig::ap_info() {
         std::string result;
 

--- a/FluidNC/src/WebUI/WifiConfig.h
+++ b/FluidNC/src/WebUI/WifiConfig.h
@@ -79,6 +79,7 @@ namespace WebUI {
         static std::string webInfo();
 
         static std::string station_info();
+        static std::string getIP();
         static std::string ap_info();
 
         static bool isValidIP(const char* string);


### PR DESCRIPTION
This makes it so that if findmymaslow and maslow.local both don't work there is still a way to find the machine's IP address. It will blink it out and you can write it down with a pencil and paper.