### PR TITLE
Add a separate threshold for calibration limit

### DIFF
--- a/FluidNC/data/maslow.yaml
+++ b/FluidNC/data/maslow.yaml
@@ -1,7 +1,7 @@
 board: Maslow
 name: Maslow S3 Board
 
-Maslow_vertical: true
+Maslow_vertical: false
 Maslow_calibration_offset: 500
 
 Maslow_tlX: -31
@@ -17,6 +17,7 @@ Maslow_brX: 2952
 Maslow_brY: 0.0
 
 Maslow_Retract_Current_Threshold: 1300
+Maslow_Calibration_Current_Threshold: 1300
 
 spi:
   miso_pin: gpio.13

--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -54,6 +54,7 @@ namespace Machine {
         handler.item("Maslow_blY", Maslow.blY);
 
         handler.item("Maslow_Retract_Current_Threshold", Maslow.retractCurrentThreshold, 0, 3500);
+        handler.item("Maslow_Calibration_Current_Threshold", Maslow.calibrationCurrentThreshold, 0, 3500);
 
         handler.section("stepping", _stepping);
 

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -654,14 +654,14 @@ bool Maslow_::take_measurement(int waypoint, int dir, int run) {
         //On the left side of the sheet we want to pull the left belt tight first
         if (x < 0) {
             if (!BL_tight) {
-                if (axisBL.pull_tight()) {
+                if (axisBL.pull_tight(calibrationCurrentThreshold)) {
                     BL_tight = true;
                     //log_info("Pulled BL tight");
                 }
                 return false;
             }
             if (!BR_tight) {
-                if (axisBR.pull_tight()) {
+                if (axisBR.pull_tight(calibrationCurrentThreshold)) {
                     BR_tight = true;
                     //log_info("Pulled BR tight");
                 }
@@ -672,14 +672,14 @@ bool Maslow_::take_measurement(int waypoint, int dir, int run) {
         //On the right side of the sheet we want to pull the right belt tight first
         else {
             if (!BR_tight) {
-                if (axisBR.pull_tight()) {
+                if (axisBR.pull_tight(calibrationCurrentThreshold)) {
                     BR_tight = true;
                     //log_info("Pulled BR tight");
                 }
                 return false;
             }
             if (!BL_tight) {
-                if (axisBL.pull_tight()) {
+                if (axisBL.pull_tight(calibrationCurrentThreshold)) {
                     BL_tight = true;
                     //log_info("Pulled BL tight");
                 }
@@ -757,7 +757,7 @@ bool Maslow_::take_measurement(int waypoint, int dir, int run) {
         holdAxis1->recomputePID();
         holdAxis2->recomputePID();
         if (!pull1_tight) {
-            if (pullAxis1->pull_tight()) {
+            if (pullAxis1->pull_tight(calibrationCurrentThreshold)) {
                 pull1_tight      = true;
                 String axisLabel = "";
                 if (pullAxis1 == &axisTL)
@@ -775,7 +775,7 @@ bool Maslow_::take_measurement(int waypoint, int dir, int run) {
             return false;
         }
         if (!pull2_tight) {
-            if (pullAxis2->pull_tight()) {
+            if (pullAxis2->pull_tight(calibrationCurrentThreshold)) {
                 pull2_tight      = true;
                 String axisLabel = "";
                 if (pullAxis2 == &axisTL)

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -101,6 +101,7 @@ public:
     MotorUnit axisBL;
     MotorUnit axisBR;
     int retractCurrentThreshold = 1300;
+    int calibrationCurrentThreshold = 1300;
 
     bool axisBLHomed;
     bool axisBRHomed;

--- a/FluidNC/src/Maslow/MotorUnit.cpp
+++ b/FluidNC/src/Maslow/MotorUnit.cpp
@@ -169,7 +169,7 @@ bool MotorUnit::comply() {
 
 // Pulls_tight and zeros axis; returns true when done
 bool MotorUnit::retract() {
-    if (pull_tight()) {
+    if (pull_tight(absoluteCurrentThreshold)) {
         log_info(_encoderAddress << " pulled tight with offset " << getPosition());
         zero();
         return true;
@@ -178,7 +178,7 @@ bool MotorUnit::retract() {
 }
 
 // Pulls the belt until we hit a current treshold; returns true when done
-bool MotorUnit::pull_tight() {
+bool MotorUnit::pull_tight(int currentThreshold) {
     //call every 5ms
     if (millis() - lastCallToRetract < 5) {
         return false;
@@ -209,7 +209,7 @@ bool MotorUnit::pull_tight() {
     //     }
     // }
     if (retract_speed > 75) {
-        if (currentMeasurement > absoluteCurrentThreshold || incrementalThresholdHits > 2 ||
+        if (currentMeasurement > currentThreshold || incrementalThresholdHits > 2 ||
             beltStalled) {  //changed from 4 to 2 to prevent overtighting
             //stop motor, reset variables
             stop();

--- a/FluidNC/src/Maslow/MotorUnit.h
+++ b/FluidNC/src/Maslow/MotorUnit.h
@@ -30,7 +30,7 @@ public:
     bool   comply();
     bool   retract();
     bool   extend(double targetLength);
-    bool   pull_tight();
+    bool   pull_tight(int currentThreshold);
     bool   motor_test();
     bool   test();
     void   reset();  //resetting variables here, because of non-blocking, maybe there's a better way to do this


### PR DESCRIPTION
This splits out the threshold used during the calibration process from the one used during the "Retract All" process so that they can be different.