### PR TITLE
Add a warning if frame is too small for offset

### DIFF
--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -1014,7 +1014,7 @@ int Maslow_::get_direction(double x, double y, double targetX, double targetY) {
 }
 
 // Generate calibration points based on dimentions
-void Maslow_::generate_calibration_grid() {
+bool Maslow_::generate_calibration_grid() {
     int gridSizeX = CALIBRATION_GRID_X;
     int gridSizeY = CALIBRATION_GRID_Y;
     int xSpacing  = (trX - 2 * calibration_grid_offset) / gridSizeX;
@@ -1024,12 +1024,12 @@ void Maslow_::generate_calibration_grid() {
     //Check to make sure that the offset is less than 1/2 of the frame width
     if (calibration_grid_offset > trX / 2) {
         log_error("Calibration grid offset is greater than half the frame width");
-        return;
+        return false;
     }
     //Check to make sure that the offset is less than 1/2 of the frame height
     if (calibration_grid_offset > trY / 2) {
         log_error("Calibration grid offset is greater than half the frame height");
-        return;
+        return false;
     }
 
     log_info("gridSizeX " << gridSizeX << " gridSizeY " << gridSizeY << " xSpacing " << xSpacing << " ySpacing " << ySpacing);
@@ -1051,6 +1051,7 @@ void Maslow_::generate_calibration_grid() {
             }
         }
     }
+    return true;
 }
 
 //------------------------------------------------------
@@ -1108,11 +1109,11 @@ void Maslow_::extendALL() {
     //extendCallTimer = millis();
 }
 void Maslow_::runCalibration() {
-    generate_calibration_grid();
-    stop();
 
-    // test = true;
-    // return;
+    if(!generate_calibration_grid()){
+        return;
+    }
+    stop();
 
     //if not all axis are homed, we can't run calibration, OR if the user hasnt entered width and height?
     if (!all_axis_homed()) {

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -1020,6 +1020,18 @@ void Maslow_::generate_calibration_grid() {
     int xSpacing  = (trX - 2 * calibration_grid_offset) / gridSizeX;
     int ySpacing  = (trY - 2 * calibration_grid_offset) / gridSizeY;
     pointCount    = 0;
+
+    //Check to make sure that the offset is less than 1/2 of the frame width
+    if (calibration_grid_offset > trX / 2) {
+        log_error("Calibration grid offset is greater than half the frame width");
+        return;
+    }
+    //Check to make sure that the offset is less than 1/2 of the frame height
+    if (calibration_grid_offset > trY / 2) {
+        log_error("Calibration grid offset is greater than half the frame height");
+        return;
+    }
+
     log_info("gridSizeX " << gridSizeX << " gridSizeY " << gridSizeY << " xSpacing " << xSpacing << " ySpacing " << ySpacing);
 
     for (int i = -gridSizeX / 2; i <= gridSizeX / 2; i++) {

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -119,7 +119,7 @@ public:
     double calibrationGrid[CALIBRATION_GRID_SIZE][2] = { 0 };
     float  calibration_grid_offset                   = 620;  // mm offset from the edge of the frame
     bool   error                                     = false;
-    void   generate_calibration_grid();
+    bool   generate_calibration_grid();
     bool   move_with_slack(double fromX, double fromY, double toX, double toY);
     int    get_direction(double x, double y, double targetX, double targetY);
     bool   take_measurement_avg_with_check(int waypoint, int dir);


### PR DESCRIPTION
If we attempt to offset the corners of the calibration points by more than 1/2 the width of the frame then the top left point will actually end up below the bottom left point and it would in theory be possible to have points outside the anchor points entirely which causes the process to fail.

This PR adds an error message which will exit the calibration process and explain the issue.