### PR TITLE
Add warning to take slack explaining that belts need to be retracted

### DIFF
--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -1167,6 +1167,12 @@ void Maslow_::set_frame_height(double height) {
     updateCenterXY();
 }
 void Maslow_::take_slack() {
+    //if not all axis are homed, we can't take the slack up
+    if (!all_axis_homed()) {
+        log_error("Cannot take slack until all axis are retracted and extended");
+        sys.set_state(State::Idle);
+        return;
+    }
     retractingTL = false;
     retractingTR = false;
     retractingBL = false;


### PR DESCRIPTION
It was confusing if you pressed "Take Slack" before retracting and extending the belts because there was no clear indication of why the machine wasn't doing it.