### PR TITLE
Warnings and guards on take slack and calibration if belts aren't fully extended 

### DIFF
--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -1118,8 +1118,8 @@ void Maslow_::runCalibration() {
     stop();
 
     //if not all axis are homed, we can't run calibration, OR if the user hasnt entered width and height?
-    if (!all_axis_homed()) {
-        log_error("Cannot run calibration until all axis are retracted and extended");
+    if (!allAxisExtended()) {
+        log_error("Cannot run calibration until all axis are extended fully");
         sys.set_state(State::Idle);
         return;
     }
@@ -1164,8 +1164,8 @@ void Maslow_::set_frame_height(double height) {
 }
 void Maslow_::take_slack() {
     //if not all axis are homed, we can't take the slack up
-    if (!all_axis_homed()) {
-        log_error("Cannot take slack until all axis are retracted and extended");
+    if (!allAxisExtended()) {
+        log_error("Cannot take slack until all axis are extended fully");
         sys.set_state(State::Idle);
         return;
     }


### PR DESCRIPTION
You could run take slack or calibration without fully extending the belts first which would lead to unpredictable behavior. This will add guards and a warning to prevent that from happening 