### PR TITLE
Add better warnings on alarm state

### DIFF
--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -101,6 +101,7 @@ void Maslow_::update() {
             st = !st;
             digitalWrite(REDLED, st);
             timer = millis();
+            log_error(errorMessage.c_str());
         }
         return;
     }
@@ -1304,6 +1305,8 @@ void Maslow_::eStop() {
     log_warn("The machine will not respond until turned off and back on again");
     stop();
     error = true;
+    errorMessage = "Emergency stop triggered.";
+    sys.set_state(State::Alarm);
 }
 
 // Get's the most recently set target position in X

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -122,6 +122,7 @@ public:
     float  calibration_grid_offset_Y                 = 500;  // mm offset from the edge of the frame
     double calibrationDataWaiting                    = -1;   //-1 if data is not waiting, other wise the milis since the data was last sent
     bool   error                                     = false;
+    String errorMessage;
     bool   generate_calibration_grid();
     bool   move_with_slack(double fromX, double fromY, double toX, double toY);
     int    get_direction(double x, double y, double targetX, double targetY);

--- a/FluidNC/src/Maslow/MotorUnit.cpp
+++ b/FluidNC/src/Maslow/MotorUnit.cpp
@@ -24,6 +24,7 @@ void MotorUnit::begin(int forwardPin, int backwardPin, int readbackPin, int enco
     if (!encoder.begin()) {
         log_error("Encoder not found on " << Maslow.axis_id_to_label(_encoderAddress).c_str());
         Maslow.error = true;
+        Maslow.errorMessage = "Encoder not found on " + Maslow.axis_id_to_label(_encoderAddress);
     } else {
         log_info("Encoder connected on " << Maslow.axis_id_to_label(_encoderAddress).c_str());
     }
@@ -37,6 +38,7 @@ void MotorUnit::begin(int forwardPin, int backwardPin, int readbackPin, int enco
     if (!motor_test()) {
         log_error("Motor not found on " << Maslow.axis_id_to_label(_encoderAddress).c_str());
         Maslow.error = true;
+        Maslow.errorMessage = "Motor not found on " + Maslow.axis_id_to_label(_encoderAddress);
     } else {
         log_info("Motor detected on " << Maslow.axis_id_to_label(_encoderAddress).c_str());
     }
@@ -47,6 +49,7 @@ bool MotorUnit::test() {
     if (!motor_test()) {
         log_warn("Motor not found on " << Maslow.axis_id_to_label(_encoderAddress).c_str());
         Maslow.error = true;
+        Maslow.errorMessage = "Motor not found on " + Maslow.axis_id_to_label(_encoderAddress);
     } else {
         log_info("Motor detected on " << Maslow.axis_id_to_label(_encoderAddress).c_str());
     }
@@ -54,6 +57,7 @@ bool MotorUnit::test() {
     if (!updateEncoderPosition()) {
         log_warn("Encoder not found on " << Maslow.axis_id_to_label(_encoderAddress).c_str());
         Maslow.error = true;
+        Maslow.errorMessage = "Encoder not found on " + Maslow.axis_id_to_label(_encoderAddress);
     } else {
         log_info("Encoder connected on " << Maslow.axis_id_to_label(_encoderAddress).c_str());
     }


### PR DESCRIPTION
This adds a repeating warning if the machine has entered the alarm state so that it is more clear what is going on. The old system only displayed the alarm once which was easy to miss.