### PR TITLE
 Special sauce to dismiss captive portal assistant on Apple devices.

### DIFF
--- a/FluidNC/src/WebUI/WebServer.cpp
+++ b/FluidNC/src/WebUI/WebServer.cpp
@@ -158,6 +158,11 @@ namespace WebUI {
             _webserver->on("/gconnectivitycheck.gstatic.com", HTTP_ANY, handle_root);
             //do not forget the / at the end
             _webserver->on("/fwlink/", HTTP_ANY, handle_root);
+                        //Added special sauce for Apple devices. They will try to connect to this URL to check if they are behind a captive portal.
+            _webserver->on("/hotspot-detect.html", HTTP_ANY, [](){
+                _webserver->send(200, "text/html", "<HTML><HEAD><TITLE>Success</TITLE></HEAD><BODY>Success</BODY></HTML>");
+            });
+
         }
 
         //SSDP service presentation


### PR DESCRIPTION
Apple devices try to connect to a few URLs looking for a specific response to determine internet access and if behind captive portal. There are newer/better ways to do this now, but this is consistent with the special cases in place for other platforms. There are probably some others that could be added, but need to set up testing (windows mostly.