### PR TITLE
change min frame size to 16 in

### DIFF
--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -126,7 +126,7 @@ public:
 
     //calibration stuff
 
-    int frame_dimention_MIN = 1000;
+    int frame_dimention_MIN = 400;
     int frame_dimention_MAX = 5000;
 
     double calibrationGrid[CALIBRATION_GRID_SIZE_MAX][2] = { 0 };


### PR DESCRIPTION
addresses issue #100 

400mm is small enough that there is no usable space, but that makes anything larger theoretically usable