### PR TITLE
Make stop always stop gcode job

### DIFF
--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -1623,6 +1623,9 @@ void Maslow_::stop() {
     axisTR.reset();
     axisBL.reset();
     axisBR.reset();
+
+    // if we are stopping, stop any running job too
+    allChannels.stopJob();
 }
 
 // Stop all the motors
@@ -1636,7 +1639,6 @@ void Maslow_::stopMotors() {
 static void stopEverything() {
     sys.set_state(State::Alarm);
     protocol_disable_steppers();
-    allChannels.stopJob();
 }
 
 // Panic function, stops all motors and sets state to alarm

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -336,7 +336,7 @@ static Error home(AxisMask axisMask) {
 static Error home_all(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
     AxisMask requestedAxes = Machine::Homing::AllCycles;
     auto     retval        = Error::Ok;
-    
+
     // value can be a list of cycle numbers like "21", which will run homing cycle 2 then cycle 1,
     // or a list of axis names like "XZ", which will home the X and Z axes simultaneously
     if (value) {
@@ -823,7 +823,7 @@ static Error showHeap(const char* value, WebUI::AuthenticationLevel auth_level, 
 
 /*
 
-                
+
               //////////  Maslow-specific user cmd functions  //////////////
 
 
@@ -1154,7 +1154,7 @@ void make_user_commands() {
     new UserCommand("TEST", "Maslow/test", maslow_test, anyState);
     new UserCommand("TKSLK", "Maslow/takeSlack", maslow_takeSlack, anyState);
     new UserCommand("ACKCAL", "Maslow/ackCalibration", maslow_ack_cal, anyState);
-    new UserCommand("ESTOP", "Maslow/stop", maslow_estop, anyState);
+    new UserCommand("ESTOP", "Maslow/estop", maslow_estop, anyState);
 
 };
 


### PR DESCRIPTION
@BarbourSmith 

My last one didn't stop gcode on every type of "stop" so this addresses that. I won't need anything on the firmware side for the stop/estop/pause/resume ui changes but stop has to stop the job. Also deconflicting long name for estop from stop.
