### PR TITLE
M4 default config

### DIFF
--- a/FluidNC/data/maslow.yaml
+++ b/FluidNC/data/maslow.yaml
@@ -6,7 +6,7 @@ Maslow_vertical: false
 
 # Define the distance from the anchor points to the corners of the calibration grid in mm
 maslow_calibration_grid_width_mm_X: 2000
-maslow_calibraiton_grid_height_mm_Y: 1000
+maslow_calibration_grid_height_mm_Y: 1000
 
 # Defines the number of points in the calibration grid. Options are 3,5,7,9
 maslow_calibration_grid_size: 9

--- a/FluidNC/src/Logging.h
+++ b/FluidNC/src/Logging.h
@@ -57,6 +57,7 @@ extern bool atMsgLevel(MsgLevel level);
 #define log_info(x) if (atMsgLevel(MsgLevelInfo)) { LogStream ss("[MSG:INFO: "); ss << x; }
 #define log_warn(x) if (atMsgLevel(MsgLevelWarning)) { LogStream ss("[MSG:WARN: "); ss << x; }
 #define log_error(x) if (atMsgLevel(MsgLevelError)) { LogStream ss("[MSG:ERR: "); ss << x; }
+#define log_config_error(x) if (atMsgLevel(MsgLevelError)) { LogStream ss("[MSG:ERR: "); ss << x; }
 #define log_fatal(x) { LogStream ss("[MSG:FATAL: "); ss << x;  Assert(false, "A fatal error occurred."); }
 
 #define log_msg_to(out, x) { LogStream ss(out, "[MSG: "); ss << x; }

--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -44,7 +44,11 @@ namespace Machine {
         handler.section("stepping", _stepping);
 
         handler.section("uart1", _uarts[1], 1);
-        /*
+
+        // The following could all be commented out and left to defaults from FluidNC
+        // uart2, uart_channel1, uart_channel2, i2so, i2c0, i2c1,
+        // kinematics,
+        // control, coolant, probe, macros, start, parking, user_outputs, oled
         handler.section("uart2", _uarts[2], 2);
 
         handler.section("uart_channel1", _uart_channels[1]);
@@ -54,17 +58,13 @@ namespace Machine {
 
         handler.section("i2c0", _i2c[0], 0);
         handler.section("i2c1", _i2c[1], 1);
-        */
 
         handler.section("spi", _spi);
         handler.section("sdcard", _sdCard);
 
-        /*
         handler.section("kinematics", _kinematics);
-        */
         handler.section("axes", _axes);
 
-        /*
         handler.section("control", _control);
         handler.section("coolant", _coolant);
         handler.section("probe", _probe);
@@ -76,7 +76,6 @@ namespace Machine {
         handler.section("user_outputs", _userOutputs);
 
         handler.section("oled", _oled);
-        */
 
         Spindles::SpindleFactory::factory(handler, _spindles);
 
@@ -84,7 +83,7 @@ namespace Machine {
         Listeners::SysListenerFactory::factory(handler, _sysListeners);
 
         // TODO: Consider putting these under a gcode: hierarchy level? Or motion control?
-        /*
+        // The following could all be commented out and left to defaults from FluidNC
         handler.item("arc_tolerance_mm", _arcTolerance, 0.001, 1.0);
         handler.item("junction_deviation_mm", _junctionDeviation, 0.01, 1.0);
         handler.item("verbose_errors", _verboseErrors);
@@ -92,7 +91,6 @@ namespace Machine {
         handler.item("enable_parking_override_control", _enableParkingOverrideControl);
         handler.item("use_line_numbers", _useLineNumbers);
         handler.item("planner_blocks", _planner_blocks, 10, 120);
-        */
     }
 
     void MachineConfig::groupM4Items(Configuration::HandlerBase& handler) {

--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -15,14 +15,14 @@
 #include "../SettingsDefinitions.h"  // config_filename
 #include "../FileStream.h"
 
-
 #include "../Configuration/Parser.h"
 #include "../Configuration/ParserHandler.h"
 #include "../Configuration/Validator.h"
 #include "../Configuration/AfterParse.h"
 #include "../Configuration/ParseException.h"
 #include "../Config.h"  // ENABLE_*
-#include "../Maslow/Maslow.h" //using_default_config
+
+#include "../Maslow/Maslow.h" // using_default_config
 
 #include <cstdio>
 #include <cstring>
@@ -38,6 +38,64 @@ namespace Machine {
         handler.item("name", _name);
         handler.item("meta", _meta);
 
+        groupM4Items(handler);
+
+        // Maslow M4 - Limited sections
+        handler.section("stepping", _stepping);
+
+        handler.section("uart1", _uarts[1], 1);
+        /*
+        handler.section("uart2", _uarts[2], 2);
+
+        handler.section("uart_channel1", _uart_channels[1]);
+        handler.section("uart_channel2", _uart_channels[2]);
+
+        handler.section("i2so", _i2so);
+
+        handler.section("i2c0", _i2c[0], 0);
+        handler.section("i2c1", _i2c[1], 1);
+        */
+
+        handler.section("spi", _spi);
+        handler.section("sdcard", _sdCard);
+
+        /*
+        handler.section("kinematics", _kinematics);
+        */
+        handler.section("axes", _axes);
+
+        /*
+        handler.section("control", _control);
+        handler.section("coolant", _coolant);
+        handler.section("probe", _probe);
+        handler.section("macros", _macros);
+
+        handler.section("start", _start);
+        handler.section("parking", _parking);
+
+        handler.section("user_outputs", _userOutputs);
+
+        handler.section("oled", _oled);
+        */
+
+        Spindles::SpindleFactory::factory(handler, _spindles);
+
+        // Maslow M4 Specific?
+        Listeners::SysListenerFactory::factory(handler, _sysListeners);
+
+        // TODO: Consider putting these under a gcode: hierarchy level? Or motion control?
+        /*
+        handler.item("arc_tolerance_mm", _arcTolerance, 0.001, 1.0);
+        handler.item("junction_deviation_mm", _junctionDeviation, 0.01, 1.0);
+        handler.item("verbose_errors", _verboseErrors);
+        handler.item("report_inches", _reportInches);
+        handler.item("enable_parking_override_control", _enableParkingOverrideControl);
+        handler.item("use_line_numbers", _useLineNumbers);
+        handler.item("planner_blocks", _planner_blocks, 10, 120);
+        */
+    }
+
+    void MachineConfig::groupM4Items(Configuration::HandlerBase& handler) {
         handler.item("Maslow_vertical", Maslow.orientation);
         handler.item("maslow_calibration_grid_width_mm_X", Maslow.calibration_grid_width_mm_X, 100, 3000);
         handler.item("maslow_calibration_grid_height_mm_Y", Maslow.calibration_grid_height_mm_Y, 100, 3000);
@@ -62,62 +120,16 @@ namespace Machine {
         handler.item("Maslow_Retract_Current_Threshold", Maslow.retractCurrentThreshold, 0, 3500);
         handler.item("Maslow_Calibration_Current_Threshold", Maslow.calibrationCurrentThreshold, 0, 3500);
         handler.item("Maslow_Acceptable_Calibration_Threshold", Maslow.acceptableCalibrationThreshold, 0, 1);
-
-        handler.section("stepping", _stepping);
-
-        handler.section("uart1", _uarts[1], 1);
-        handler.section("uart2", _uarts[2], 2);
-
-        handler.section("uart_channel1", _uart_channels[1]);
-        handler.section("uart_channel2", _uart_channels[2]);
-
-        handler.section("i2so", _i2so);
-
-        handler.section("i2c0", _i2c[0], 0);
-        handler.section("i2c1", _i2c[1], 1);
-
-        handler.section("spi", _spi);
-        handler.section("sdcard", _sdCard);
-
-        handler.section("kinematics", _kinematics);
-        handler.section("axes", _axes);
-
-        handler.section("control", _control);
-        handler.section("coolant", _coolant);
-        handler.section("probe", _probe);
-        handler.section("macros", _macros);
-        handler.section("extenders", _extenders);
-        handler.section("start", _start);
-        handler.section("parking", _parking);
-
-        handler.section("user_outputs", _userOutputs);
-
-        handler.section("oled", _oled);
-
-        Spindles::SpindleFactory::factory(handler, _spindles);
-        Listeners::SysListenerFactory::factory(handler, _sysListeners);
-
-        // TODO: Consider putting these under a gcode: hierarchy level? Or motion control?
-        handler.item("arc_tolerance_mm", _arcTolerance, 0.001, 1.0);
-        handler.item("junction_deviation_mm", _junctionDeviation, 0.01, 1.0);
-        handler.item("verbose_errors", _verboseErrors);
-        handler.item("report_inches", _reportInches);
-        handler.item("enable_parking_override_control", _enableParkingOverrideControl);
-        handler.item("use_line_numbers", _useLineNumbers);
-        handler.item("planner_blocks", _planner_blocks, 10, 120);
-
-
-
-        
-        
     }
 
     void MachineConfig::afterParse() {
         if (_axes == nullptr) {
-            log_info("Axes: using defaults");
+            log_config_error("Maslow M4 expects the 'axes' section to be defined in the file or the default config");
+            // The following is NOT expected to yield the correct result for the M4
             _axes = new Axes();
         }
 
+        // coolant, kinematics, probe, userOutputs all run with their FluidNC defaults
         if (_coolant == nullptr) {
             _coolant = new CoolantControl();
         }
@@ -135,20 +147,26 @@ namespace Machine {
         }
 
         if (_sdCard == nullptr) {
+            log_config_error("Maslow M4 expects the 'scCard' section to be defined in the file or the default config");
+            // The following is NOT expected to yield the correct result for the M4
             _sdCard = new SDCard();
         }
 
         if (_spi == nullptr) {
+            log_config_error("Maslow M4 expects the 'spi' section to be defined in the file or the default config");
+            // The following is NOT expected to yield the correct result for the M4
             _spi = new SPIBus();
         }
 
         if (_stepping == nullptr) {
+            log_config_error("Maslow M4 expects the 'stepping' section to be defined in the file or the default config");
+            // The following is NOT expected to yield the correct result for the M4
             _stepping = new Stepping();
         }
 
         // We do not auto-create an I2SO bus config node
         // Only if an i2so section is present will config->_i2so be non-null
-
+        // control, start, parking all run with their FluidNC defaults
         if (_control == nullptr) {
             _control = new Control();
         }
@@ -176,44 +194,58 @@ namespace Machine {
             }
         }
 
+        // macros runs with its FluidNC defaults
         if (_macros == nullptr) {
             _macros = new Macros();
         }
     }
 
-    char defaultConfig[] = "name: Default (Test Drive)\nboard: None\n";
+    const char defaultConfig[] =
+        "name: Default (Maslow S3 Board)\nboard: Maslow\n"
+        "spi:\n  miso_pin: gpio.13\n  mosi_pin: gpio.11\n  sck_pin: gpio.12\n"
+        "sdcard:\n  card_detect_pin: NO_PIN\n  cs_pin: gpio.10\n"
+        "stepping:\n  engine: RMT\n  idle_ms: 240\n"
+        "uart1:\n  txd_pin: gpio.1\n  rxd_pin: gpio.2\n  baud: 115200\n  mode: 8N1\n"
+        "axes:\n"
+        "  x:\n    max_rate_mm_per_min: 2000\n    acceleration_mm_per_sec2: 25\n    max_travel_mm: 2438.4\n    homing:\n      cycle: -1\n\n"
+        "    motor0:\n      dc_servo:\n\n"
+        "  y:\n    max_rate_mm_per_min: 2000\n    acceleration_mm_per_sec2: 25\n    max_travel_mm: 1219.2\n    homing:\n      cycle: -1\n\n"
+        "  z:\n    max_rate_mm_per_min: 400\n    acceleration_mm_per_sec2: 10\n    max_travel_mm: 100\n    steps_per_mm: 100\n    homing:\n      cycle: -1\n\n"
+        "    motor0:\n      tmc_2209:\n        uart_num: 1\n        addr: 0\n        cs_pin: NO_PIN\n        r_sense_ohms: 0.110\n        run_amps: 1.000\n        hold_amps: 0.500\n        microsteps: 0\n        stallguard: 0\n        stallguard_debug: false\n        toff_disable: 0\n        toff_stealthchop: 5\n        toff_coolstep: 3\n        run_mode: StealthChop\n        homing_mode: StealthChop\n        use_enable: true\n        direction_pin: gpio.16\n        step_pin: gpio.15\n\n"
+        "    motor1:\n      tmc_2209:\n        uart_num: 1\n        addr: 1\n        cs_pin: NO_PIN\n        r_sense_ohms: 0.110\n        run_amps: 1.000\n        hold_amps: 0.500\n        microsteps: 0\n        stallguard: 0\n        stallguard_debug: false\n        toff_disable: 0\n        toff_stealthchop: 5\n        toff_coolstep: 3\n        run_mode: StealthChop\n        homing_mode: StealthChop\n        use_enable: true\n        direction_pin: gpio.38\n        step_pin: gpio.46\n\n";
 
     bool MachineConfig::load() {
         bool configOkay;
-        //If the system crashes we skip the config file and use the default
-        //builtin config.  This helps prevent reset loops on bad config files.
+
+        // If the system crashes we skip the config file and use the default
+        // builtin config.  This helps prevent reset loops on bad config files.
         esp_reset_reason_t reason = esp_reset_reason();
 
         // TEST: Uncomment the following to mock an ESP panic reset
-        // reason = ESP_RST_PANIC;
+        //reason = ESP_RST_PANIC;
         if (reason == ESP_RST_PANIC) {
             log_error("Skipping configuration file due to panic");
             configOkay = false;
         } else {
-            configOkay = load(config_filename->get());
+            configOkay = load_file(config_filename->get());
         }
 
         if (!configOkay) {
             log_info("Using default configuration");
-            configOkay = load(new StringRange(defaultConfig));
+            configOkay = load_yaml(new StringRange(defaultConfig));
             Maslow.using_default_config = true;
         }
         //configOkay = load(config_filename->get());
         return configOkay;
     }
 
-    bool MachineConfig::load(const char* filename) {
+    bool MachineConfig::load_file(const char* filename) {
         try {
-            FileStream file(filename, "r", "");
+            FileStream file(std::string { filename }, "r", "");
 
             auto filesize = file.size();
             if (filesize <= 0) {
-                log_info("Configuration file:" << filename << " is empty");
+                log_config_error("Configuration file:" << filename << " is empty");
                 return false;
             }
 
@@ -221,20 +253,20 @@ namespace Machine {
             buffer[filesize] = '\0';
             auto actual      = file.read(buffer, filesize);
             if (actual != filesize) {
-                log_info("Configuration file:" << filename << " read error");
+                log_config_error("Configuration file:" << filename << " read error");
                 return false;
             }
-            log_info("Configuration file:" << filename);
-            bool retval = load(new StringRange(buffer, buffer + filesize));
+            log_config_error("Configuration file:" << filename);
+            bool retval = load_yaml(new StringRange(buffer, buffer + filesize));
             delete[] buffer;
             return retval;
         } catch (...) {
-            log_warn("Cannot open configuration file:" << filename);
+            log_config_error("Cannot open configuration file:" << filename);
             return false;
         }
     }
 
-    bool MachineConfig::load(StringRange* input) {
+    bool MachineConfig::load_yaml(StringRange* input) {
         bool successful = false;
         try {
             Configuration::Parser        parser(input->begin(), input->end());
@@ -267,36 +299,37 @@ namespace Machine {
                 Configuration::Validator validator;
                 config->validate();
                 config->group(validator);
-            } catch (std::exception& ex) { log_error("Validation error: " << ex.what()); }
+            } catch (std::exception& ex) {
+                log_config_error("Validation error: " << ex.what());
+            }
 
             // log_info("Heap size after configuation load is " << uint32_t(xPortGetFreeHeapSize()));
 
             successful = (sys.state() != State::ConfigAlarm);
 
             if (!successful) {
-                log_error("Configuration is invalid");
+                log_config_error("Configuration is invalid");
             }
-
         } catch (const Configuration::ParseException& ex) {
             sys.set_state(State::ConfigAlarm);
-            log_error("Configuration parse error on line " << ex.LineNumber() << ": " << ex.What());
+            log_config_error("Configuration parse error on line " << ex.LineNumber() << ": " << ex.What());
         } catch (const AssertionFailed& ex) {
             sys.set_state(State::ConfigAlarm);
             // Get rid of buffer and return
-            log_error("Configuration loading failed: " << ex.what());
+            log_config_error("Configuration loading failed: " << ex.what());
         } catch (std::exception& ex) {
             sys.set_state(State::ConfigAlarm);
             // Log exception:
-            log_error("Configuration validation error: " << ex.what());
+            log_config_error("Configuration validation error: " << ex.what());
         } catch (...) {
             sys.set_state(State::ConfigAlarm);
             // Get rid of buffer and return
-            log_error("Unknown error while processing config file");
+            log_config_error("Unknown error while processing config file");
         }
         delete[] input;
 
         std::atomic_thread_fence(std::memory_order::memory_order_seq_cst);
-
+        
         return successful;
     }
 
@@ -309,5 +342,21 @@ namespace Machine {
         delete _spi;
         delete _control;
         delete _macros;
+
+        // Maslow M4 specific?
+        delete _extenders;
+
+        // Also, what about ...
+        /*
+        delete _kinematics;
+        delete _stepping;
+        delete _userOutputs;
+        delete _start;
+        delete _parking;
+        delete _oled;
+        */
+
+        // And proper deletion of
+        // _i2c[MAX_N_I2C], _uart_channels[MAX_N_UARTS], _uarts[MAX_N_UARTS]
     }
 }

--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -98,22 +98,23 @@ namespace Machine {
         handler.item("maslow_calibration_grid_width_mm_X", Maslow.calibration_grid_width_mm_X, 100, 3000);
         handler.item("maslow_calibration_grid_height_mm_Y", Maslow.calibration_grid_height_mm_Y, 100, 3000);
         handler.item("maslow_calibration_grid_size", Maslow.calibrationGridSize, 3, 9);
-        
-        handler.item("Maslow_brX", Maslow.brX);
-        handler.item("Maslow_brY", Maslow.brY);
-        handler.item("Maslow_brZ", Maslow.brZ);
-        
+
         handler.item("Maslow_tlX", Maslow.tlX);
         handler.item("Maslow_tlY", Maslow.tlY);
-        handler.item("Maslow_tlZ", Maslow.tlZ);
 
         handler.item("Maslow_trX", Maslow.trX);
         handler.item("Maslow_trY", Maslow.trY);
-        handler.item("Maslow_trZ", Maslow.trZ);
 
         handler.item("Maslow_blX", Maslow.blX);
         handler.item("Maslow_blY", Maslow.blY);
+        
+        handler.item("Maslow_brX", Maslow.brX);
+        handler.item("Maslow_brY", Maslow.brY);
+
+        handler.item("Maslow_tlZ", Maslow.tlZ);
+        handler.item("Maslow_trZ", Maslow.trZ);
         handler.item("Maslow_blZ", Maslow.blZ);
+        handler.item("Maslow_brZ", Maslow.brZ);
 
         handler.item("Maslow_Retract_Current_Threshold", Maslow.retractCurrentThreshold, 0, 3500);
         handler.item("Maslow_Calibration_Current_Threshold", Maslow.calibrationCurrentThreshold, 0, 3500);
@@ -198,19 +199,50 @@ namespace Machine {
         }
     }
 
-    const char defaultConfig[] =
-        "name: Default (Maslow S3 Board)\nboard: Maslow\n"
-        "spi:\n  miso_pin: gpio.13\n  mosi_pin: gpio.11\n  sck_pin: gpio.12\n"
-        "sdcard:\n  card_detect_pin: NO_PIN\n  cs_pin: gpio.10\n"
-        "stepping:\n  engine: RMT\n  idle_ms: 240\n"
-        "uart1:\n  txd_pin: gpio.1\n  rxd_pin: gpio.2\n  baud: 115200\n  mode: 8N1\n"
+    // Common Default Config partial strings
+    const std::string M = "Maslow";
+    const std::string mcgrid = "maslow_calibration_grid_";
+
+    // Individual Default Config items and sections
+    const std::string dcBoard = "name: Default ("+M+" S3 Board)\nboard: "+M+"\n";
+
+    const std::string dcM4Vert = M+"_vertical: false\n";
+    const std::string dcM4CalibrationGrid = mcgrid + "width_mm_X: 2000\n" + mcgrid + "height_mm_Y: 1000\n" + mcgrid + "size: 9\n";
+
+    const std::string dcM4Anchors =
+        M+"_tlX: -27.6\n"+M+"_tlY: 2064.9\n"
+        +M+"_trX: 2924.3\n"+M+"_trY: 2066.5\n"
+        +M+"_blX: 0\n"+M+"_blY: 0\n"
+        +M+"_brX: 2953.2\n"+M+"_brY: 0\n";
+    const std::string dcM4ZAxis = M+"_tlZ: 100\n"+M+"_trZ: 56\n"+M+"_blZ: 34\n"+M+"_brZ: 78\n";
+
+    const std::string dcM4CurrentThreshold = M+"_Retract_Current_Threshold: 1300\n"+M+"_Calibration_Current_Threshold: 1500\n"+M+"_Acceptable_Calibration_Threshold: 0.5\n";
+
+    const std::string dcSpi = "spi:\n  miso_pin: gpio.13\n  mosi_pin: gpio.11\n  sck_pin: gpio.12\n";
+    const std::string dcSDCard = "sdcard:\n  card_detect_pin: NO_PIN\n  cs_pin: gpio.10\n";
+    const std::string dcStepping = "stepping:\n  engine: RMT\n  idle_ms: 240\n";
+    const std::string dcUart1 = "uart1:\n  txd_pin: gpio.1\n  rxd_pin: gpio.2\n  baud: 115200\n  mode: 8N1\n";
+
+    const std::string dcZMotor = 
+        "        uart_num: 1\n        cs_pin: NO_PIN\n        r_sense_ohms: 0.110\n"
+        "        run_amps: 1.000\n        hold_amps: 0.500\n        microsteps: 0\n"
+        "        stallguard: 0\n        stallguard_debug: false\n"
+        "        toff_disable: 0\n        toff_stealthchop: 5\n        toff_coolstep: 3\n"
+        "        run_mode: StealthChop\n        homing_mode: StealthChop\n        use_enable: true\n";
+
+    const std::string defaultConfig =
+        dcBoard +
+        // Maslow M4 default items
+        dcM4Vert + dcM4CalibrationGrid + dcM4Anchors + dcM4ZAxis + dcM4CurrentThreshold +
+        // Default sections
+        dcSpi + dcSDCard + dcStepping + dcUart1 + 
         "axes:\n"
-        "  x:\n    max_rate_mm_per_min: 2000\n    acceleration_mm_per_sec2: 25\n    max_travel_mm: 2438.4\n    homing:\n      cycle: -1\n\n"
-        "    motor0:\n      dc_servo:\n\n"
-        "  y:\n    max_rate_mm_per_min: 2000\n    acceleration_mm_per_sec2: 25\n    max_travel_mm: 1219.2\n    homing:\n      cycle: -1\n\n"
-        "  z:\n    max_rate_mm_per_min: 400\n    acceleration_mm_per_sec2: 10\n    max_travel_mm: 100\n    steps_per_mm: 100\n    homing:\n      cycle: -1\n\n"
-        "    motor0:\n      tmc_2209:\n        uart_num: 1\n        addr: 0\n        cs_pin: NO_PIN\n        r_sense_ohms: 0.110\n        run_amps: 1.000\n        hold_amps: 0.500\n        microsteps: 0\n        stallguard: 0\n        stallguard_debug: false\n        toff_disable: 0\n        toff_stealthchop: 5\n        toff_coolstep: 3\n        run_mode: StealthChop\n        homing_mode: StealthChop\n        use_enable: true\n        direction_pin: gpio.16\n        step_pin: gpio.15\n\n"
-        "    motor1:\n      tmc_2209:\n        uart_num: 1\n        addr: 1\n        cs_pin: NO_PIN\n        r_sense_ohms: 0.110\n        run_amps: 1.000\n        hold_amps: 0.500\n        microsteps: 0\n        stallguard: 0\n        stallguard_debug: false\n        toff_disable: 0\n        toff_stealthchop: 5\n        toff_coolstep: 3\n        run_mode: StealthChop\n        homing_mode: StealthChop\n        use_enable: true\n        direction_pin: gpio.38\n        step_pin: gpio.46\n\n";
+        "  x:\n    max_rate_mm_per_min: 2000\n    acceleration_mm_per_sec2: 25\n    max_travel_mm: 2438.4\n    homing:\n      cycle: -1\n"
+        "    motor0:\n      dc_servo:\n"
+        "  y:\n    max_rate_mm_per_min: 2000\n    acceleration_mm_per_sec2: 25\n    max_travel_mm: 1219.2\n    homing:\n      cycle: -1\n"
+        "  z:\n    max_rate_mm_per_min: 400\n    acceleration_mm_per_sec2: 10\n    max_travel_mm: 100\n    steps_per_mm: 100\n    homing:\n      cycle: -1\n"
+        "    motor0:\n      tmc_2209:\n        addr: 0\n        direction_pin: gpio.16\n        step_pin: gpio.15\n" + dcZMotor +
+        "    motor1:\n      tmc_2209:\n        addr: 1\n        direction_pin: gpio.38\n        step_pin: gpio.46\n" + dcZMotor;
 
     bool MachineConfig::load() {
         bool configOkay;
@@ -230,7 +262,7 @@ namespace Machine {
 
         if (!configOkay) {
             log_info("Using default configuration");
-            configOkay = load_yaml(new StringRange(defaultConfig));
+            configOkay = load_yaml(new StringRange(defaultConfig.c_str()));
             Maslow.using_default_config = true;
         }
         //configOkay = load(config_filename->get());

--- a/FluidNC/src/Machine/MachineConfig.h
+++ b/FluidNC/src/Machine/MachineConfig.h
@@ -12,6 +12,7 @@
 #include "../Kinematics/Kinematics.h"
 #include "../WebUI/BTConfig.h"
 #include "../Extenders/Extenders.h"
+
 #include "../Control.h"
 #include "../Probe.h"
 #include "../Parking.h"
@@ -24,6 +25,7 @@
 #include "../UartChannel.h"
 #include "../Uart.h"
 #include "../Listeners/SysListener.h"
+
 #include "Axes.h"
 #include "SPIBus.h"
 #include "I2CBus.h"
@@ -61,21 +63,22 @@ namespace Machine {
     public:
         MachineConfig() = default;
 
-        Axes*                      _axes           = nullptr;
-        Kinematics*                _kinematics     = nullptr;
-        SPIBus*                    _spi            = nullptr;
-        I2CBus*                    _i2c[MAX_N_I2C] = { nullptr };
-        I2SOBus*                   _i2so           = nullptr;
-        Stepping*                  _stepping       = nullptr;
-        CoolantControl*            _coolant        = nullptr;
-        Probe*                     _probe          = nullptr;
-        Control*                   _control        = nullptr;
-        UserOutputs*               _userOutputs    = nullptr;
-        SDCard*                    _sdCard         = nullptr;
-        Macros*                    _macros         = nullptr;
-        Start*                     _start          = nullptr;
-        Parking*                   _parking        = nullptr;
-        OLED*                      _oled           = nullptr;
+        Axes*                 _axes           = nullptr;
+        Kinematics*           _kinematics     = nullptr;
+        SPIBus*               _spi            = nullptr;
+        I2CBus*               _i2c[MAX_N_I2C] = { nullptr };
+        I2SOBus*              _i2so           = nullptr;
+        Stepping*             _stepping       = nullptr;
+        CoolantControl*       _coolant        = nullptr;
+        Probe*                _probe          = nullptr;
+        Control*              _control        = nullptr;
+        UserOutputs*          _userOutputs    = nullptr;
+        SDCard*               _sdCard         = nullptr;
+        Macros*               _macros         = nullptr;
+        Start*                _start          = nullptr;
+        Parking*              _parking        = nullptr;
+        OLED*                 _oled           = nullptr;
+
         Listeners::SysListenerList _sysListeners;
         Spindles::SpindleList      _spindles;
         Extenders::Extenders*      _extenders = nullptr;
@@ -112,9 +115,12 @@ namespace Machine {
         void afterParse() override;
         void group(Configuration::HandlerBase& handler) override;
 
+        // Maslow M4 Specific
+        void groupM4Items(Configuration::HandlerBase& handler);
+
         static bool load();
-        static bool load(const char* file);
-        static bool load(StringRange* input);
+        static bool load_file(const char* filename);
+        static bool load_yaml(StringRange* input);
 
         ~MachineConfig();
     };


### PR DESCRIPTION
- Fixes a typo in the default `Maslow.yaml`

- Some sorta matching of what's in the latest FluidNC:
  - Adds a macro `log_config_error`
  - Renames `load` to be `load`, `load_file` or `load_yaml`
  - Breaks out the more M4 specific item settings into their own function

- Builds a full M4 compatible default config, for use in the case of ESP_RST_PANIC, or just supporting general 'Save'.
