### PR TITLE
Makes the machine stop moving after a FluidNC crash

### DIFF
--- a/FluidNC/src/Main.cpp
+++ b/FluidNC/src/Main.cpp
@@ -35,6 +35,7 @@ void setup() {
     // dummyUart0->begin();
 
     //Start out with the motor drivers disabled
+    //TODO: This is a bit of a hack. We shouldn't be setting the pins here.
     #define tlIn1Pin 45
     #define tlIn2Pin 21
     #define trIn1Pin 42

--- a/FluidNC/src/Main.cpp
+++ b/FluidNC/src/Main.cpp
@@ -34,6 +34,33 @@ void setup() {
     // dummyUart0->_rxd_pin = Pin::create("gpio.17");
     // dummyUart0->begin();
 
+    //Start out with the motor drivers disabled
+    #define tlIn1Pin 45
+    #define tlIn2Pin 21
+    #define trIn1Pin 42
+    #define trIn2Pin 41
+    #define blIn1Pin 37
+    #define blIn2Pin 36
+    #define brIn1Pin 9
+    #define brIn2Pin 3
+    pinMode(tlIn1Pin, OUTPUT);
+    pinMode(tlIn2Pin, OUTPUT);
+    pinMode(trIn1Pin, OUTPUT);
+    pinMode(trIn2Pin, OUTPUT);
+    pinMode(blIn1Pin, OUTPUT);
+    pinMode(blIn2Pin, OUTPUT);
+    pinMode(brIn1Pin, OUTPUT);
+    pinMode(brIn2Pin, OUTPUT);
+
+    digitalWrite(tlIn1Pin, LOW);
+    digitalWrite(tlIn2Pin, LOW);
+    digitalWrite(trIn1Pin, LOW);
+    digitalWrite(trIn2Pin, LOW);
+    digitalWrite(blIn1Pin, LOW);
+    digitalWrite(blIn2Pin, LOW);
+    digitalWrite(brIn1Pin, LOW);
+    digitalWrite(brIn2Pin, LOW);
+
     disableCore0WDT();
     try {
         // uartInit();       // Setup serial port

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -89,10 +89,13 @@ void Maslow_::begin(void (*sys_rt)()) {
 
     loadZPos(); //Loads the z-axis position from EEPROM
 
+    stopMotors();
+
     if (error) {
         log_error("Maslow failed to initialize - fix errors and restart");
-    } else
+    } else {
         log_info("Starting Maslow Version " << VERSION_NUMBER);
+    }
 }
 
 // Maslow main loop, everything is processed here
@@ -179,8 +182,7 @@ void Maslow_::update() {
         else if (sys.state() == State::Homing) {
             home();
         } else {  //In any other state, keep motors off
-            if (!test)
-                Maslow.stopMotors();
+            Maslow.stopMotors();
         }
 
         //If we are in any state other than idle or alarm turn the cooling fan on

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -261,7 +261,7 @@ static void check_startup_state() {
             settings_execute_startup();  // Execute startup script.
         }
     }
-    if(!Maslow.using_default_config) Maslow.begin(&protocol_exec_rt_system);
+    Maslow.begin(&protocol_exec_rt_system);
 }
 
 const uint32_t heapWarnThreshold = 15000;


### PR DESCRIPTION
If FluidNC crashes the machine would reboot but not properly stop the motors. This will stop the motors immediately on boot so if the machine crashes and reboots it will stop in place immediately.