### PR TITLE
Catch over current errors only while running or jogging

### DIFF
--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -599,7 +599,7 @@ void Maslow_::safety_control() {
         if (axis[i]->getMotorCurrent() > 4000 && !tick[i]) {
             panicCounter[i]++;
             if (panicCounter[i] > tresholdHitsBeforePanic) {
-                if(!calibrationInProgress){
+                if(sys.state() != State::Jog && sys.state() != State::Cycle){
                     log_error("Motor current on " << axis_id_to_label(i).c_str() << " axis exceeded threshold of " << 4000);
                     Maslow.panic();
                 }


### PR DESCRIPTION
This error at other times is usually a false reading and it's tripping folks up