### PR TITLE
Fix `log_config_error` that should be `log_info`

### DIFF
--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -286,7 +286,7 @@ namespace Machine {
                 log_config_error("Configuration file:" << filename << " read error");
                 return false;
             }
-            log_config_error("Configuration file:" << filename);
+            log_info("Configuration file:" << filename);
             bool retval = load_yaml(new StringRange(buffer, buffer + filesize));
             delete[] buffer;
             return retval;


### PR DESCRIPTION
In fixing all of the other `log_info` messages that definitely were supposed to be `log_config_error` this on was not meant to change.

So now it is changed back to a `log_info`.