### PR TITLE
add per-arm extensions and expose arm length

### DIFF
--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -116,6 +116,14 @@ namespace Machine {
         handler.item("Maslow_blZ", Maslow.blZ);
         handler.item("Maslow_brZ", Maslow.brZ);
 
+        handler.item("Maslow_tlext", Maslow.tlExt);
+        handler.item("Maslow_trext", Maslow.trExt);
+        handler.item("Maslow_blext", Maslow.blExt);
+        handler.item("Maslow_brext", Maslow.brExt);
+        
+	handler.item("Maslow_belt_anchor_length", Maslow._beltEndExtension);
+        handler.item("Maslow_arm_length", Maslow.armLength);
+
         handler.item("Maslow_Retract_Current_Threshold", Maslow.retractCurrentThreshold, 0, 3500);
         handler.item("Maslow_Calibration_Current_Threshold", Maslow.calibrationCurrentThreshold, 0, 3500);
         handler.item("Maslow_Acceptable_Calibration_Threshold", Maslow.acceptableCalibrationThreshold, 0, 1);

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -399,10 +399,10 @@ bool Maslow_::takeSlackFunc() {
             double offset = _beltEndExtension + _armLength;
             double threshold = 15;
 
-            float diffTL = calibration_data[0][0] - offset - computeTL(0, 0, 0);
-            float diffTR = calibration_data[1][0] - offset - computeTR(0, 0, 0);
-            float diffBL = calibration_data[2][0] - offset - computeBL(0, 0, 0);
-            float diffBR = calibration_data[3][0] - offset - computeBR(0, 0, 0);
+            float diffTL = calibration_data[0][0] - offset - tlExt - computeTL(0, 0, 0);
+            float diffTR = calibration_data[1][0] - offset - trExt - computeTR(0, 0, 0);
+            float diffBL = calibration_data[2][0] - offset - blExt - computeBL(0, 0, 0);
+            float diffBR = calibration_data[3][0] - offset - brExt - computeBR(0, 0, 0);
             log_info("Center point deviation: TL: " << diffTL << " TR: " << diffTR << " BL: " << diffBL << " BR: " << diffBR);
             if (abs(diffTL) > threshold || abs(diffTR) > threshold || abs(diffBL) > threshold || abs(diffBR) > threshold) {
                 log_error("Center point deviation over " << threshold << "mmm, your coordinate system is not accurate, maybe try running calibration again?");
@@ -672,7 +672,7 @@ float Maslow_::computeBL(float x, float y, float z) {
     float b = blY - y;
     float c = 0.0 - (z + blZ);
 
-    float length = sqrt(a * a + b * b + c * c) - (_beltEndExtension + _armLength);
+    float length = sqrt(a * a + b * b + c * c) - (_beltEndExtension + _armLength + blExt);
 
     return length;  //+ lowerBeltsExtra;
 }
@@ -684,7 +684,7 @@ float Maslow_::computeBR(float x, float y, float z) {
     float b = brY - y;
     float c = 0.0 - (z + brZ);
 
-    float length = sqrt(a * a + b * b + c * c) - (_beltEndExtension + _armLength);
+    float length = sqrt(a * a + b * b + c * c) - (_beltEndExtension + _armLength + brExt);
 
     return length;  //+ lowerBeltsExtra;
 }
@@ -695,7 +695,7 @@ float Maslow_::computeTR(float x, float y, float z) {
     float a = trX - x;
     float b = trY - y;
     float c = 0.0 - (z + trZ);
-    return sqrt(a * a + b * b + c * c) - (_beltEndExtension + _armLength);
+    return sqrt(a * a + b * b + c * c) - (_beltEndExtension + _armLength + trExt);
 }
 float Maslow_::computeTL(float x, float y, float z) {
     //Move from lower left corner coordinates to centered coordinates
@@ -704,7 +704,7 @@ float Maslow_::computeTL(float x, float y, float z) {
     float a = tlX - x;
     float b = tlY - y;
     float c = 0.0 - (z + tlZ);
-    return sqrt(a * a + b * b + c * c) - (_beltEndExtension + _armLength);
+    return sqrt(a * a + b * b + c * c) - (_beltEndExtension + _armLength + tlExt);
 }
 
 //------------------------------------------------------
@@ -761,10 +761,10 @@ bool Maslow_::take_measurement(int waypoint, int dir, int run) {
         //once both belts are pulled, take a measurement
         if (BR_tight && BL_tight) {
             //take measurement and record it to the calibration data array
-            calibration_data[0][waypoint] = axisTL.getPosition() + _beltEndExtension + _armLength;
-            calibration_data[1][waypoint] = axisTR.getPosition() + _beltEndExtension + _armLength;
-            calibration_data[2][waypoint] = axisBL.getPosition() + _beltEndExtension + _armLength;
-            calibration_data[3][waypoint] = axisBR.getPosition() + _beltEndExtension + _armLength;
+            calibration_data[0][waypoint] = axisTL.getPosition() + _beltEndExtension + _armLength + tlExt;
+            calibration_data[1][waypoint] = axisTR.getPosition() + _beltEndExtension + _armLength + trExt;
+            calibration_data[2][waypoint] = axisBL.getPosition() + _beltEndExtension + _armLength + blExt;
+            calibration_data[3][waypoint] = axisBR.getPosition() + _beltEndExtension + _armLength + brExt;
             BR_tight                      = false;
             BL_tight                      = false;
             return true;
@@ -854,10 +854,10 @@ bool Maslow_::take_measurement(int waypoint, int dir, int run) {
         }
         if (pull1_tight && pull2_tight) {
             //take measurement and record it to the calibration data array
-            calibration_data[0][waypoint] = axisTL.getPosition() + _beltEndExtension + _armLength;
-            calibration_data[1][waypoint] = axisTR.getPosition() + _beltEndExtension + _armLength;
-            calibration_data[2][waypoint] = axisBL.getPosition() + _beltEndExtension + _armLength;
-            calibration_data[3][waypoint] = axisBR.getPosition() + _beltEndExtension + _armLength;
+            calibration_data[0][waypoint] = axisTL.getPosition() + _beltEndExtension + _armLength + tlExt;
+            calibration_data[1][waypoint] = axisTR.getPosition() + _beltEndExtension + _armLength + trExt;
+            calibration_data[2][waypoint] = axisBL.getPosition() + _beltEndExtension + _armLength + blExt;
+            calibration_data[3][waypoint] = axisBR.getPosition() + _beltEndExtension + _armLength + brExt;
             pull1_tight                   = false;
             pull2_tight                   = false;
             return true;
@@ -944,10 +944,10 @@ bool Maslow_::take_measurement_avg_with_check(int waypoint, int dir) {
                 double offset = _beltEndExtension + _armLength;
                 double threshold = 100;
 
-                float diffTL = calibration_data[0][0] - offset - computeTL(0, 0, 0);
-                float diffTR = calibration_data[1][0] - offset - computeTR(0, 0, 0);
-                float diffBL = calibration_data[2][0] - offset - computeBL(0, 0, 0);
-                float diffBR = calibration_data[3][0] - offset - computeBR(0, 0, 0);
+                float diffTL = calibration_data[0][0] - offset - tlExt - computeTL(0, 0, 0);
+                float diffTR = calibration_data[1][0] - offset - trExt - computeTR(0, 0, 0);
+                float diffBL = calibration_data[2][0] - offset - blExt - computeBL(0, 0, 0);
+                float diffBR = calibration_data[3][0] - offset - brExt - computeBR(0, 0, 0);
                 log_info("Center point deviation: TL: " << diffTL << " TR: " << diffTR << " BL: " << diffBL << " BR: " << diffBR);
 
                 if (abs(diffTL) > threshold || abs(diffTR) > threshold || abs(diffBL) > threshold || abs(diffBR) > threshold) {

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -180,22 +180,26 @@ public:
     float tlX;
     float tlY;
     float tlZ;
+    float tlExt = 0;
     float trX;
     float trY;
     float trZ;
+    float trExt = 0;
     float blX;
     float blY;
     float blZ;
+    float blExt = 0;
     float brX;
     float brY;
     float brZ;
+    float brExt = 0;
+
+    float _beltEndExtension = 30;  //Based on the CAD model these should add to 153.4
+    float _armLength        = 123.4;
 
 private:
     float centerX;
     float centerY;
-
-    float _beltEndExtension = 30;  //Based on the CAD model these should add to 153.4
-    float _armLength        = 123.4;
 
     //Used to keep track of how often the PID controller is updated
     unsigned long lastCallToPID    = millis();


### PR DESCRIPTION
Expose _armLength (Maslow_arm_length) and _beltEndExtension (Maslow_belt_anchor_length) in the yaml file to support non-standard sizes.

add Maslow_(tl/tr/bl/br)Ext keys to the yaml file as (tl/tr/bl/br)Ext variables to allow for custom length extensions to exist on the ends of belts (either to allow frames larger than the belt will reach, or to allow a clamp to be put on the belt so that retraction stops early, allowing us to avoid having to fully detach the belts for a retract cycle)

I don't have a setup to be able to compile and test these changes, but they seem very straightforward.
I think that these all get set to proper defaults if there is nothing in the yaml file, but it is possible that these will require a synced yaml change.