### PR TITLE
working telemetry process

### DIFF
--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -25,8 +25,41 @@
 
 #define MASLOW_TELEM_FILE "M4_telemetry.bin"
 
+struct TelemetryFileHeader {
+    unsigned int structureSize; // 4 bytes
+    char version[10];       // 10
+    // if you add to the header take bytes from this
+    char _unused[64]; // 64 bytes
+};
+
 struct TelemetryData {
-    unsigned long millis;
+    unsigned long timestamp;
+    // motors
+    double tlCurrent;
+    double trCurrent;
+    double blCurrent;
+    double brCurrent;
+    // power
+    double tlPower;
+    double trPower;
+    double blPower;
+    double brPower;
+    // speed
+    double tlSpeed;
+    double trSpeed;
+    double blSpeed;
+    double brSpeed;
+     // position
+    double tlPos;
+    double trPos;
+    double blPos;
+    double brPos;
+
+    int tlState;
+    int trState;
+    int blState;
+    int brState;
+
     bool extendedTL;
     bool extendedTR;
     bool extendedBL;

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -886,6 +886,18 @@ static Error maslow_stop(const char* value, WebUI::AuthenticationLevel auth_leve
     Maslow.stop();
     return Error::Ok;
 }
+static Error maslow_telemetry_dump(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+    if (!value || !*value) {
+        value = std::string(MASLOW_TELEM_FILE).c_str();
+    }
+    // TODO: only call if the file exists
+    Maslow.dump_telemetry(value);
+    return Error::Ok;
+}
+static Error maslow_telemetry_toggle(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+    Maslow.set_telemetry(!Maslow.telemetry_enabled);
+    return Error::Ok;
+}
 static Error maslow_set_comply(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
     if(Maslow.using_default_config) {
         return Error::ConfigurationInvalid;
@@ -1153,6 +1165,8 @@ void make_user_commands() {
     new UserCommand("BL", "Maslow/retractBL", maslow_retract_BL, anyState);
     new UserCommand("ALL", "Maslow/retract", maslow_retract_ALL, anyState);
     new UserCommand("EXT", "Maslow/extend", maslow_extend_ALL, anyState);
+    new UserCommand("TELEMDUMP", "Maslow/telemetryDump", maslow_telemetry_dump, anyState);
+    new UserCommand("TELEM", "Maslow/toggleTelemetry", maslow_telemetry_toggle, anyState);
     new UserCommand("CMP", "Maslow/comply", maslow_set_comply, anyState);
     new UserCommand("CAL", "Maslow/calibrate", maslow_start_calibration, anyState);
 

--- a/FluidNC/src/Protocol.cpp
+++ b/FluidNC/src/Protocol.cpp
@@ -18,7 +18,7 @@
 #include "MotionControl.h"  // PARKING_MOTION_LINE_NUMBER
 #include "Settings.h"       // settings_execute_startup
 #include "Machine/LimitPin.h"
-
+#include "FileStream.h"
 #include "./Maslow/Maslow.h"
 
 volatile ExecAlarm rtAlarm;  // Global realtime executor bitflag variable for setting various alarms.
@@ -173,9 +173,32 @@ void output_loop(void* unused) {
 
 Channel* activeChannel = nullptr;  // Channel associated with the input line
 
+TaskHandle_t telemetryTask = nullptr;
+
 TaskHandle_t pollingTask = nullptr;
 
 char activeLine[Channel::maxLine];
+
+void stop_telemetry() {
+    if (telemetryTask) {
+        vTaskSuspend(telemetryTask);
+    }
+}
+
+void start_telemetry() {
+    if (telemetryTask) {
+        vTaskResume(telemetryTask);
+    } else {
+        xTaskCreatePinnedToCore(telemetry_loop,  // task
+                                "telemetry",     // name for task
+                                16000,             // size of task stack
+                                0,                 // parameters
+                                1,                 // priority
+                                &telemetryTask,       // task handle
+                                SUPPORT_TASK_CORE  // core
+        );
+    }
+}
 
 bool pollingPaused = false;
 void polling_loop(void* unused) {
@@ -209,7 +232,7 @@ void start_polling() {
     if (pollingTask) {
         vTaskResume(pollingTask);
     } else {
-        xTaskCreatePinnedToCore(polling_loop,      // task
+       xTaskCreatePinnedToCore(polling_loop,      // task
                                 "poller",          // name for task
                                 8192,              // size of task stack
                                 0,                 // parameters
@@ -227,6 +250,7 @@ void start_polling() {
                                 SUPPORT_TASK_CORE  // core
         );
     }
+
 }
 
 static void check_startup_state() {
@@ -270,6 +294,7 @@ uint32_t heapLowWater = UINT_MAX;
 void     protocol_main_loop() {
     check_startup_state();
     start_polling();
+    start_telemetry();
 
     // ---------------------------------------------------------------------------------
     // Primary loop! Upon a system abort, this exits back to main() to reset the system.
@@ -299,6 +324,7 @@ void     protocol_main_loop() {
 
         if (sys.abort()) {
             stop_polling();
+            stop_telemetry();
 
             return;  // Bail to main() program loop to reset system.
         }
@@ -479,7 +505,7 @@ static void protocol_do_feedhold() {
         runLimitLoop = false;  // Hack to stop show_limits()
         return;
     }
-    
+
     // log_debug("protocol_do_feedhold " << state_name());
     // Execute a feed hold with deceleration, if required. Then, suspend system.
     switch (sys.state()) {
@@ -828,12 +854,12 @@ void protocol_exec_rt_system() {
     if (rtSafetyDoor) {
         protocol_do_safety_door();
     }
-  
+
     //Maslow.recomputePID(); //This one works as an alternative to having recomputePID called in DCServo.cpp
 
     protocol_handle_events();
 
-    
+
     //do all the Maslow stuff here
     Maslow.update();
     // Reload step segment buffer


### PR DESCRIPTION
@BarbourSmith - This is not intended to merge (yet), but to give you a heads up of what I've been up to. 

This starts a task on the second core that we can use to gather telemetry data as the machine operates. It creates a (right now 5k) buffer that it stores data into and when its full appends it to a file on the SD card. 

By default this is turned off, but a new $TELEM command has been added that toggles it(I was thinking I'll have it take an argument y/n that will let you specifically turn it on or off). When its on, the telemetry loop will execute every half-second to grab what I thought might be good values and store them in the buffer.  

Another new command $TELEMDUMP will load the file and dump it to the serial in json-ish format for every measurement.

I also need to add more of a header than just structure size  (e.g. firmware version, other?) so we can change the data structure and be able to detect that its not compatible with the dump feature. Also configuration for how often to collect, etc. there are many possibilities. Also not sure about the thread safety concerns. As I'm mostly reading primitive values, I think we probably won't end up with half an int or anything like that, but the structure values might not be a true snapshot given values can change under it as the dump runs.  I'd like to see how that goes before going to any mutex protection of the variables as a whole.

My thoughts on this are to be able to add a debugging feature to the UI to start recording telemetry, kick off an operation (calibration, cutting, whatever), then stop and dump the telemetry where it can be analyzed. 

I have not yet tested this thoroughly but will start putting it through its paces over the next few weeks. 

Is there anything you think would be useful to gather that I can add to this? Do you think it is even a useful feature for any of the issues you've seen happening?
