### PR TITLE
Decrease minimum calibration threshold

### DIFF
--- a/FluidNC/data/maslow.yaml
+++ b/FluidNC/data/maslow.yaml
@@ -47,7 +47,7 @@ Maslow_Retract_Current_Threshold: 1300
 # Sets how hard should Maslow pull on the belts during the calibration process.
 Maslow_Calibration_Current_Threshold: 1500
 # Sets the acceptable fitness threshold for moving on to the next calibration round.
-Maslow_Acceptable_Calibration_Threshold: 0.5
+Maslow_Acceptable_Calibration_Threshold: 0.45
 
 
 ####################


### PR DESCRIPTION
Decreases the minimum acceptable calibration threshold to 0.45. 0.5 seems too high