### PR TITLE
update belt length calculation to account for arms not tilting

### DIFF
--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -739,7 +739,6 @@ float Maslow_::computeTL(float x, float y, float z) {
 // Takes one measurement; returns true when it's done. Waypoint # is used to st
 bool Maslow_::take_measurement(int waypoint, int dir, int run) {
 
-    float a,b,c;
     //Shouldn't this be handled with the same code as below but with the direction set to UP?
     if (orientation == VERTICAL) {
         //first we pull two bottom belts tight one after another, if x<0 we pull left belt first, if x>0 we pull right belt first
@@ -787,22 +786,10 @@ bool Maslow_::take_measurement(int waypoint, int dir, int run) {
         //once both belts are pulled, take a measurement
         if (BR_tight && BL_tight) {
             //take measurement and record it to the calibration data array
-            b = z + tlZ;
-            c = axisTL.getPosition();
-            a=sqrt( ( c * c ) - ( b * b ) );
-            calibration_data[0][waypoint] = a + _beltEndExtension + _armLength;
-            b = z + trZ;
-            c = axisTR.getPosition();
-            a=sqrt( ( c * c ) - ( b * b ) );
-            calibration_data[1][waypoint] = a + _beltEndExtension + _armLength;
-            b = z + blZ;
-            c = axisBL.getPosition();
-            a=sqrt( ( c * c ) - ( b * b ) );
-            calibration_data[2][waypoint] = a + _beltEndExtension + _armLength;
-            b = z + brZ;
-            c = axisBR.getPosition();
-            a=sqrt( ( c * c ) - ( b * b ) );
-            calibration_data[3][waypoint] = a + _beltEndExtension + _armLength;
+            calibration_data[0][waypoint] = axisTL.getPosition() + _beltEndExtension + _armLength;
+            calibration_data[1][waypoint] = axisTR.getPosition() + _beltEndExtension + _armLength;
+            calibration_data[2][waypoint] = axisBL.getPosition() + _beltEndExtension + _armLength;
+            calibration_data[3][waypoint] = axisBR.getPosition() + _beltEndExtension + _armLength;
             BR_tight                      = false;
             BL_tight                      = false;
             return true;
@@ -892,22 +879,10 @@ bool Maslow_::take_measurement(int waypoint, int dir, int run) {
         }
         if (pull1_tight && pull2_tight) {
             //take measurement and record it to the calibration data array
-            b = z + tlZ;
-            c = axisTL.getPosition();
-            a=sqrt( ( c * c ) - ( b * b ) );
-            calibration_data[0][waypoint] = a + _beltEndExtension + _armLength;
-            b = z + trZ;
-            c = axisTR.getPosition();
-            a=sqrt( ( c * c ) - ( b * b ) );
-            calibration_data[1][waypoint] = a + _beltEndExtension + _armLength;
-            b = z + blZ;
-            c = axisBL.getPosition();
-            a=sqrt( ( c * c ) - ( b * b ) );
-            calibration_data[2][waypoint] = a + _beltEndExtension + _armLength;
-            b = tlZ;
-            c = axisBR.getPosition();
-            a=sqrt( ( c * c ) - ( b * b ) );
-            calibration_data[3][waypoint] = a + _beltEndExtension + _armLength;
+            calibration_data[0][waypoint] = axisTL.getPosition() + _beltEndExtension + _armLength;
+            calibration_data[1][waypoint] = axisTR.getPosition() + _beltEndExtension + _armLength;
+            calibration_data[2][waypoint] = axisBL.getPosition() + _beltEndExtension + _armLength;
+            calibration_data[3][waypoint] = axisBR.getPosition() + _beltEndExtension + _armLength;
             pull1_tight                   = false;
             pull2_tight                   = false;
             return true;

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -739,6 +739,7 @@ float Maslow_::computeTL(float x, float y, float z) {
 // Takes one measurement; returns true when it's done. Waypoint # is used to st
 bool Maslow_::take_measurement(int waypoint, int dir, int run) {
 
+    float a,b,c;
     //Shouldn't this be handled with the same code as below but with the direction set to UP?
     if (orientation == VERTICAL) {
         //first we pull two bottom belts tight one after another, if x<0 we pull left belt first, if x>0 we pull right belt first
@@ -786,10 +787,22 @@ bool Maslow_::take_measurement(int waypoint, int dir, int run) {
         //once both belts are pulled, take a measurement
         if (BR_tight && BL_tight) {
             //take measurement and record it to the calibration data array
-            calibration_data[0][waypoint] = axisTL.getPosition() + _beltEndExtension + _armLength;
-            calibration_data[1][waypoint] = axisTR.getPosition() + _beltEndExtension + _armLength;
-            calibration_data[2][waypoint] = axisBL.getPosition() + _beltEndExtension + _armLength;
-            calibration_data[3][waypoint] = axisBR.getPosition() + _beltEndExtension + _armLength;
+            b = z + tlZ;
+            c = axisTL.getPosition();
+            a=sqrt( ( c * c ) - ( b * b ) );
+            calibration_data[0][waypoint] = a + _beltEndExtension + _armLength;
+            b = z + trZ;
+            c = axisTR.getPosition();
+            a=sqrt( ( c * c ) - ( b * b ) );
+            calibration_data[1][waypoint] = a + _beltEndExtension + _armLength;
+            b = z + blZ;
+            c = axisBL.getPosition();
+            a=sqrt( ( c * c ) - ( b * b ) );
+            calibration_data[2][waypoint] = a + _beltEndExtension + _armLength;
+            b = z + brZ;
+            c = axisBR.getPosition();
+            a=sqrt( ( c * c ) - ( b * b ) );
+            calibration_data[3][waypoint] = a + _beltEndExtension + _armLength;
             BR_tight                      = false;
             BL_tight                      = false;
             return true;
@@ -879,10 +892,22 @@ bool Maslow_::take_measurement(int waypoint, int dir, int run) {
         }
         if (pull1_tight && pull2_tight) {
             //take measurement and record it to the calibration data array
-            calibration_data[0][waypoint] = axisTL.getPosition() + _beltEndExtension + _armLength;
-            calibration_data[1][waypoint] = axisTR.getPosition() + _beltEndExtension + _armLength;
-            calibration_data[2][waypoint] = axisBL.getPosition() + _beltEndExtension + _armLength;
-            calibration_data[3][waypoint] = axisBR.getPosition() + _beltEndExtension + _armLength;
+            b = z + tlZ;
+            c = axisTL.getPosition();
+            a=sqrt( ( c * c ) - ( b * b ) );
+            calibration_data[0][waypoint] = a + _beltEndExtension + _armLength;
+            b = z + trZ;
+            c = axisTR.getPosition();
+            a=sqrt( ( c * c ) - ( b * b ) );
+            calibration_data[1][waypoint] = a + _beltEndExtension + _armLength;
+            b = z + blZ;
+            c = axisBL.getPosition();
+            a=sqrt( ( c * c ) - ( b * b ) );
+            calibration_data[2][waypoint] = a + _beltEndExtension + _armLength;
+            b = tlZ;
+            c = axisBR.getPosition();
+            a=sqrt( ( c * c ) - ( b * b ) );
+            calibration_data[3][waypoint] = a + _beltEndExtension + _armLength;
             pull1_tight                   = false;
             pull2_tight                   = false;
             return true;

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -674,8 +674,12 @@ float Maslow_::computeBL(float x, float y, float z) {
     float a = blX - x;
     float b = blY - y;
     float c = 0.0 - (z + blZ);
+    // The belt is only sloped between the end of the arm and the end of the anchor
+    // not all the way to the center of the bit. This matters when near the anchors
+    // at 600mm the eror can be almost 6mm
+    float xyLen = sqrt(a * a + b * b) - (_beltEndExtension + _armLength);
 
-    float length = sqrt(a * a + b * b + c * c) - (_beltEndExtension + _armLength);
+    float length = sqrt(xyLen * xyLen + c * c);
 
     return length;  //+ lowerBeltsExtra;
 }
@@ -686,8 +690,12 @@ float Maslow_::computeBR(float x, float y, float z) {
     float a = brX - x;
     float b = brY - y;
     float c = 0.0 - (z + brZ);
+    // The belt is only sloped between the end of the arm and the end of the anchor
+    // not all the way to the center of the bit. This matters when near the anchors
+    // at 600mm the eror can be almost 6mm
+    float xyLen = sqrt(a * a + b * b) - (_beltEndExtension + _armLength);
 
-    float length = sqrt(a * a + b * b + c * c) - (_beltEndExtension + _armLength);
+    float length = sqrt(xyLen * xyLen + c * c);
 
     return length;  //+ lowerBeltsExtra;
 }
@@ -698,7 +706,14 @@ float Maslow_::computeTR(float x, float y, float z) {
     float a = trX - x;
     float b = trY - y;
     float c = 0.0 - (z + trZ);
-    return sqrt(a * a + b * b + c * c) - (_beltEndExtension + _armLength);
+    // The belt is only sloped between the end of the arm and the end of the anchor
+    // not all the way to the center of the bit. This matters when near the anchors
+    // at 600mm the eror can be almost 6mm
+    float xyLen = sqrt(a * a + b * b) - (_beltEndExtension + _armLength);
+
+    float length = sqrt(xyLen * xyLen + c * c);
+
+    return length;  //+ lowerBeltsExtra;
 }
 float Maslow_::computeTL(float x, float y, float z) {
     //Move from lower left corner coordinates to centered coordinates
@@ -707,7 +722,14 @@ float Maslow_::computeTL(float x, float y, float z) {
     float a = tlX - x;
     float b = tlY - y;
     float c = 0.0 - (z + tlZ);
-    return sqrt(a * a + b * b + c * c) - (_beltEndExtension + _armLength);
+    // The belt is only sloped between the end of the arm and the end of the anchor
+    // not all the way to the center of the bit. This matters when near the anchors
+    // at 600mm the eror can be almost 6mm
+    float xyLen = sqrt(a * a + b * b) - (_beltEndExtension + _armLength);
+
+    float length = sqrt(xyLen * xyLen + c * c);
+
+    return length;  //+ lowerBeltsExtra;
 }
 
 //------------------------------------------------------


### PR DESCRIPTION
since the arms and anchors are not in line with the belt on the Z plane, the simple belt length calculation from the anchor to the center of the bit at the Z height are not correct, at 150mm Z and 600mm x/y distance, the error is almost 6nn shorter than the old calculation

the new calculation subtracts the arm length and anchor length before compensating for the Z.