### PR TITLE
Only move belts on jog once setup has been completed

### DIFF
--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -150,6 +150,7 @@ public:
     String axis_id_to_label(int axis_id);
     bool   all_axis_homed();
     bool   allAxisExtended();
+    bool   setupComplete();
     void   safety_control();
     void   set_frame_width(double width);
     void   set_frame_height(double height);
@@ -170,6 +171,8 @@ public:
     bool takeSlack    = false;
 
     bool safetyOn = true;
+
+    bool setupIsComplete = false;
 
     //Used to override and drive the motors directly
     void TLI();


### PR DESCRIPTION
This PR is created in response to this issue: https://forums.maslowcnc.com/t/safety-suggestion/22523

This PR adds a setupComplete() function which will determine if the machine has fully been set up and prevent the XY motors from driving until it has. 