### PR TITLE
Standardize usage of the 'Maslow' string

### DIFF
--- a/FluidNC/src/Configuration/HandlerBase.h
+++ b/FluidNC/src/Configuration/HandlerBase.h
@@ -35,10 +35,10 @@ namespace Configuration {
 
     public:
         virtual void item(const char* name, bool& value)                                                            = 0;
-        virtual void item(const std::string name, bool& value) { item(&name[0], value); };
+        virtual void item(const std::string name, bool& value) { item(name.c_str(), value); };
         virtual void item(const char* name, int32_t& value, int32_t minValue = 0, int32_t maxValue = INT32_MAX)     = 0;
         virtual void item(const std::string name, int32_t& value, int32_t minValue = 0, int32_t maxValue = INT32_MAX) {
-            item(&name[0], value, minValue, maxValue);
+            item(name.c_str(), value, minValue, maxValue);
         };
         virtual void item(const char* name, uint32_t& value, uint32_t minValue = 0, uint32_t maxValue = UINT32_MAX) = 0;
 
@@ -49,13 +49,13 @@ namespace Configuration {
         }
         void item(const std::string name, uint8_t& value, uint8_t minValue = 0, uint8_t maxValue = UINT8_MAX) {
             int32_t v = int32_t(value);
-            item(&name[0], v, int32_t(minValue), int32_t(maxValue));
+            item(name.c_str(), v, int32_t(minValue), int32_t(maxValue));
             value = uint8_t(v);
         }
 
         virtual void item(const char* name, float& value, float minValue = -3e38, float maxValue = 3e38)  = 0;
         virtual void item(const std::string name, float& value, float minValue = -3e38, float maxValue = 3e38) {
-            item(&name[0], value, minValue, maxValue);
+            item(name.c_str(), value, minValue, maxValue);
         };
         virtual void item(const char* name, std::vector<speedEntry>& value)                               = 0;
         virtual void item(const char* name, UartData& wordLength, UartParity& parity, UartStop& stopBits) = 0;

--- a/FluidNC/src/Configuration/HandlerBase.h
+++ b/FluidNC/src/Configuration/HandlerBase.h
@@ -35,7 +35,11 @@ namespace Configuration {
 
     public:
         virtual void item(const char* name, bool& value)                                                            = 0;
+        virtual void item(const std::string name, bool& value) { item(&name[0], value); };
         virtual void item(const char* name, int32_t& value, int32_t minValue = 0, int32_t maxValue = INT32_MAX)     = 0;
+        virtual void item(const std::string name, int32_t& value, int32_t minValue = 0, int32_t maxValue = INT32_MAX) {
+            item(&name[0], value, minValue, maxValue);
+        };
         virtual void item(const char* name, uint32_t& value, uint32_t minValue = 0, uint32_t maxValue = UINT32_MAX) = 0;
 
         void item(const char* name, uint8_t& value, uint8_t minValue = 0, uint8_t maxValue = UINT8_MAX) {
@@ -43,8 +47,16 @@ namespace Configuration {
             item(name, v, int32_t(minValue), int32_t(maxValue));
             value = uint8_t(v);
         }
+        void item(const std::string name, uint8_t& value, uint8_t minValue = 0, uint8_t maxValue = UINT8_MAX) {
+            int32_t v = int32_t(value);
+            item(&name[0], v, int32_t(minValue), int32_t(maxValue));
+            value = uint8_t(v);
+        }
 
         virtual void item(const char* name, float& value, float minValue = -3e38, float maxValue = 3e38)  = 0;
+        virtual void item(const std::string name, float& value, float minValue = -3e38, float maxValue = 3e38) {
+            item(&name[0], value, minValue, maxValue);
+        };
         virtual void item(const char* name, std::vector<speedEntry>& value)                               = 0;
         virtual void item(const char* name, UartData& wordLength, UartParity& parity, UartStop& stopBits) = 0;
 

--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -94,36 +94,36 @@ namespace Machine {
     }
 
     void MachineConfig::groupM4Items(Configuration::HandlerBase& handler) {
-        handler.item("Maslow_vertical", Maslow.orientation);
-        handler.item("maslow_calibration_grid_width_mm_X", Maslow.calibration_grid_width_mm_X, 100, 3000);
-        handler.item("maslow_calibration_grid_height_mm_Y", Maslow.calibration_grid_height_mm_Y, 100, 3000);
-        handler.item("maslow_calibration_grid_size", Maslow.calibrationGridSize, 3, 9);
+        handler.item(M+"_vertical", Maslow.orientation);
+        handler.item(M+"_calibration_grid_width_mm_X", Maslow.calibration_grid_width_mm_X, 100, 3000);
+        handler.item(M+"_calibration_grid_height_mm_Y", Maslow.calibration_grid_height_mm_Y, 100, 3000);
+        handler.item(M+"_calibration_grid_size", Maslow.calibrationGridSize, 3, 9);
 
-        handler.item("Maslow_tlX", Maslow.tlX);
-        handler.item("Maslow_tlY", Maslow.tlY);
+        handler.item(M+"_tlX", Maslow.tlX);
+        handler.item(M+"_tlY", Maslow.tlY);
 
-        handler.item("Maslow_trX", Maslow.trX);
-        handler.item("Maslow_trY", Maslow.trY);
+        handler.item(M+"_trX", Maslow.trX);
+        handler.item(M+"_trY", Maslow.trY);
 
-        handler.item("Maslow_blX", Maslow.blX);
-        handler.item("Maslow_blY", Maslow.blY);
+        handler.item(M+"_blX", Maslow.blX);
+        handler.item(M+"_blY", Maslow.blY);
         
-        handler.item("Maslow_brX", Maslow.brX);
-        handler.item("Maslow_brY", Maslow.brY);
+        handler.item(M+"_brX", Maslow.brX);
+        handler.item(M+"_brY", Maslow.brY);
 
-        handler.item("Maslow_tlZ", Maslow.tlZ);
-        handler.item("Maslow_trZ", Maslow.trZ);
-        handler.item("Maslow_blZ", Maslow.blZ);
-        handler.item("Maslow_brZ", Maslow.brZ);
+        handler.item(M+"_tlZ", Maslow.tlZ);
+        handler.item(M+"_trZ", Maslow.trZ);
+        handler.item(M+"_blZ", Maslow.blZ);
+        handler.item(M+"_brZ", Maslow.brZ);
 
-        handler.item("Maslow_Retract_Current_Threshold", Maslow.retractCurrentThreshold, 0, 3500);
-        handler.item("Maslow_Calibration_Current_Threshold", Maslow.calibrationCurrentThreshold, 0, 3500);
-        handler.item("Maslow_Acceptable_Calibration_Threshold", Maslow.acceptableCalibrationThreshold, 0, 1);
+        handler.item(M+"_Retract_Current_Threshold", Maslow.retractCurrentThreshold, 0, 3500);
+        handler.item(M+"_Calibration_Current_Threshold", Maslow.calibrationCurrentThreshold, 0, 3500);
+        handler.item(M+"_Acceptable_Calibration_Threshold", Maslow.acceptableCalibrationThreshold, 0, 1);
     }
 
     void MachineConfig::afterParse() {
         if (_axes == nullptr) {
-            log_config_error("Maslow M4 expects the 'axes' section to be defined in the file or the default config");
+            log_config_error(M+"M4 expects the 'axes' section to be defined in the file or the default config");
             // The following is NOT expected to yield the correct result for the M4
             _axes = new Axes();
         }
@@ -146,19 +146,19 @@ namespace Machine {
         }
 
         if (_sdCard == nullptr) {
-            log_config_error("Maslow M4 expects the 'scCard' section to be defined in the file or the default config");
+            log_config_error(M+" M4 expects the 'scCard' section to be defined in the file or the default config");
             // The following is NOT expected to yield the correct result for the M4
             _sdCard = new SDCard();
         }
 
         if (_spi == nullptr) {
-            log_config_error("Maslow M4 expects the 'spi' section to be defined in the file or the default config");
+            log_config_error(M+" M4 expects the 'spi' section to be defined in the file or the default config");
             // The following is NOT expected to yield the correct result for the M4
             _spi = new SPIBus();
         }
 
         if (_stepping == nullptr) {
-            log_config_error("Maslow M4 expects the 'stepping' section to be defined in the file or the default config");
+            log_config_error(M+" M4 expects the 'stepping' section to be defined in the file or the default config");
             // The following is NOT expected to yield the correct result for the M4
             _stepping = new Stepping();
         }
@@ -200,10 +200,10 @@ namespace Machine {
     }
 
     // Common Default Config partial strings
-    const std::string M = "Maslow";
-    const std::string mcgrid = "maslow_calibration_grid_";
+    const std::string mcgrid = M+"_calibration_grid_";
 
     // Individual Default Config items and sections
+    // Default Config - Board
     const std::string dcBoard = "name: Default ("+M+" S3 Board)\nboard: "+M+"\n";
 
     const std::string dcM4Vert = M+"_vertical: false\n";
@@ -262,7 +262,7 @@ namespace Machine {
 
         if (!configOkay) {
             log_info("Using default configuration");
-            configOkay = load_yaml(new StringRange(defaultConfig.c_str()));
+            configOkay = load_yaml(new StringRange(&defaultConfig[0]));
             Maslow.using_default_config = true;
         }
         //configOkay = load(config_filename->get());

--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -262,7 +262,7 @@ namespace Machine {
 
         if (!configOkay) {
             log_info("Using default configuration");
-            configOkay = load_yaml(new StringRange(&defaultConfig[0]));
+            configOkay = load_yaml(new StringRange(defaultConfig.c_str()));
             Maslow.using_default_config = true;
         }
         //configOkay = load(config_filename->get());

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -115,7 +115,7 @@ void Maslow_::update() {
             digitalWrite(REDLED, st);
             timer = millis();
             if (errorMessage != "") {
-                log_error(&errorMessage[0]);
+                log_error(errorMessage.c_str());
             }
             errorMessage = "";
         }
@@ -535,11 +535,11 @@ bool Maslow_::updateEncoderPositions() {
             String label = axis_id_to_label(i);
             if (encoderFailCounter[i] > 0.1 * ENCODER_READ_FREQUENCY_HZ) {
                 // log error statement with appropriate label
-                log_error("Failure on " << &label[0] << " encoder, failed to read " << encoderFailCounter[i]
+                log_error("Failure on " << label.c_str() << " encoder, failed to read " << encoderFailCounter[i]
                                         << " times in the last second");
                 Maslow.panic();
             } else if (encoderFailCounter[i] > 0) {  //0.01*ENCODER_READ_FREQUENCY_HZ){
-                log_warn("Bad connection on " << &label[0] << " encoder, failed to read " << encoderFailCounter[i]
+                log_warn("Bad connection on " << label.c_str() << " encoder, failed to read " << encoderFailCounter[i]
                                               << " times in the last second");
             }
             encoderFailCounter[i] = 0;
@@ -604,7 +604,7 @@ void Maslow_::safety_control() {
             panicCounter[i]++;
             if (panicCounter[i] > tresholdHitsBeforePanic) {
                 if(sys.state() == State::Jog || sys.state() == State::Cycle){
-                    log_warn("Motor current on " << &axis_id_to_label(i)[0] << " axis exceeded threshold of " << 4000);
+                    log_warn("Motor current on " << axis_id_to_label(i).c_str() << " axis exceeded threshold of " << 4000);
                     //Maslow.panic();
                 }
                 tick[i] = true;
@@ -624,10 +624,10 @@ void Maslow_::safety_control() {
         if (axis[i]->getMotorPower() > 450 && abs(axis[i]->getBeltSpeed()) < 0.1 && !tick[i]) {
             axisSlackCounter[i]++;
             if (axisSlackCounter[i] > 3000) {
-                // log_info("SLACK:" << &axis_id_to_label(i)[0] << " motor power is " << int(axis[i]->getMotorPower())
+                // log_info("SLACK:" << axis_id_to_label(i).c_str() << " motor power is " << int(axis[i]->getMotorPower())
                 //                   << ", but the belt speed is" << axis[i]->getBeltSpeed());
                 // log_info(axisSlackCounter[i]);
-                // log_info("Pull on " << &axis_id_to_label(i)[0] << " and restart!");
+                // log_info("Pull on " << axis_id_to_label(i).c_str() << " and restart!");
                 tick[i]             = true;
                 axisSlackCounter[i] = 0;
                 Maslow.panic();
@@ -637,7 +637,7 @@ void Maslow_::safety_control() {
 
         //If the motor has a position error greater than 1mm and we are running a file or jogging
         if ((abs(axis[i]->getPositionError()) > 1) && (sys.state() == State::Jog || sys.state() == State::Cycle) && !tick[i]) {
-            // log_error("Position error on " << &axis_id_to_label(i)[0] << " axis exceeded 1mm, error is " << axis[i]->getPositionError()
+            // log_error("Position error on " << axis_id_to_label(i).c_str() << " axis exceeded 1mm, error is " << axis[i]->getPositionError()
             //                                << "mm");
             tick[i] = true;
         }
@@ -646,7 +646,7 @@ void Maslow_::safety_control() {
         previousPositionError[i] = axis[i]->getPositionError();
         if ((abs(axis[i]->getPositionError()) > 15) && (sys.state() == State::Cycle)) {
             positionErrorCounter[i]++;
-            log_warn("Position error on " << &axis_id_to_label(i)[0] << " axis exceeded 15mm while running. Error is "
+            log_warn("Position error on " << axis_id_to_label(i).c_str() << " axis exceeded 15mm while running. Error is "
                                             << axis[i]->getPositionError() << "mm" << " Counter: " << positionErrorCounter[i]);
             log_warn("Previous error was " << previousPositionError[i] << "mm");
 
@@ -947,7 +947,7 @@ bool Maslow_::take_measurement_avg_with_check(int waypoint, int dir) {
                 for (int i = 0; i < 4; i++) {
                     for (int j = 0; j < 4; j++) {
                         //use axis id to label:
-                        log_info(&axis_id_to_label(i)[0] << " " << measurements[i][j]);
+                        log_info(axis_id_to_label(i).c_str() << " " << measurements[i][j]);
                     }
                 }
                 //reset the run counter to run the measurements again

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -97,7 +97,7 @@ void Maslow_::begin(void (*sys_rt)()) {
     if (error) {
         log_error(M+" failed to initialize - fix errors and restart");
     } else {
-        log_info("Starting Maslow Version " << VERSION_NUMBER);
+        log_info("Starting "+M+" Version " << VERSION_NUMBER);
     }
 }
 
@@ -1254,7 +1254,7 @@ bool Maslow_::generate_calibration_grid() {
             numberOfCycles = 4; // 9x9 grid
             break;
         default:
-            log_error("Invalid Maslow_calibration_grid_size: " << calibrationGridSize);
+            log_error("Invalid "+M+"_calibration_grid_size: " << calibrationGridSize);
             return false; // return false or handle error appropriately
     }
 
@@ -1450,7 +1450,7 @@ void Maslow_::BLI(){
 }
 void Maslow_::BRI(){
     BRIOveride = true;
-    log_info("BRI in Maslow seen");
+    log_info("BRI in "+M+" seen");
     overideTimer = millis();
 }
 void Maslow_::TLO(){

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -1765,7 +1765,7 @@ void Maslow_::print_calibration_data() {
     }
     data += "]";
     HeartBeatEnabled = false;
-    log_data(&data[0]);
+    log_data(data.c_str());
     HeartBeatEnabled = true;
 }
 

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -25,6 +25,11 @@
 
 #define MASLOW_TELEM_FILE "M4_telemetry.bin"
 
+// Common Default strings - especially used by config
+const std::string M = "Maslow";
+// Non-volatile storage name
+const char * nvs = "maslow";
+
 struct TelemetryFileHeader {
     unsigned int structureSize; // 4 bytes
     char version[10];       // 10

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -888,7 +888,7 @@ static Error maslow_stop(const char* value, WebUI::AuthenticationLevel auth_leve
 }
 static Error maslow_telemetry_dump(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
     if (!value || !*value) {
-        value = &std::string(MASLOW_TELEM_FILE)[0];
+        value = std::string(MASLOW_TELEM_FILE).c_str();
     }
     // TODO: only call if the file exists
     Maslow.dump_telemetry(value);

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -1386,7 +1386,7 @@ void settings_execute_startup() {
             // We have to copy this to a mutable array because
             // gc_execute_line modifies the line while parsing.
             char gcline[256];
-            strncpy(gcline, &str[0], 255);
+            strncpy(gcline, str.c_str(), 255);
             status_code = gc_execute_line(gcline);
             // Uart0 << ">" << gcline << ":";
             if (status_code != Error::Ok) {

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -888,7 +888,7 @@ static Error maslow_stop(const char* value, WebUI::AuthenticationLevel auth_leve
 }
 static Error maslow_telemetry_dump(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
     if (!value || !*value) {
-        value = std::string(MASLOW_TELEM_FILE).c_str();
+        value = &std::string(MASLOW_TELEM_FILE)[0];
     }
     // TODO: only call if the file exists
     Maslow.dump_telemetry(value);
@@ -1002,7 +1002,7 @@ static Error maslow_set_width(const char* value, WebUI::AuthenticationLevel auth
     }
     if (!value) {
         //double width = Maslow.frame_width;
-        //log_info("Maslow frame width is " << width);
+        //log_info(M+" frame width is " << width);
         return Error::Ok;
     }
     char*    endptr;
@@ -1013,11 +1013,11 @@ static Error maslow_set_width(const char* value, WebUI::AuthenticationLevel auth
     }
 
     if( intValue < Maslow.frame_dimention_MIN || intValue > Maslow.frame_dimention_MAX ){
-        log_error("Maslow frame width must be between " << Maslow.frame_dimention_MIN << " and " << Maslow.frame_dimention_MAX);
+        log_error(M+" frame width must be between " << Maslow.frame_dimention_MIN << " and " << Maslow.frame_dimention_MAX);
         return Error::BadNumberFormat;
     }
     Maslow.set_frame_width(intValue);
-    log_info("Maslow frame width set to " << intValue);
+    log_info(M+" frame width set to " << intValue);
     return Error::Ok;
 }
 
@@ -1027,7 +1027,7 @@ static Error maslow_set_height(const char* value, WebUI::AuthenticationLevel aut
     }
     if (!value) {
         //double height = Maslow.frame_height;
-        //log_info("Maslow frame height is " << height);
+        //log_info(M+" frame height is " << height);
         return Error::Ok;
     }
     char*    endptr;
@@ -1038,11 +1038,11 @@ static Error maslow_set_height(const char* value, WebUI::AuthenticationLevel aut
     }
 
     if( intValue < Maslow.frame_dimention_MIN || intValue > Maslow.frame_dimention_MAX ){
-        log_error("Maslow frame height must be between " << Maslow.frame_dimention_MIN << " and " << Maslow.frame_dimention_MAX);
+        log_error(M+" frame height must be between " << Maslow.frame_dimention_MIN << " and " << Maslow.frame_dimention_MAX);
         return Error::BadNumberFormat;
     }
     Maslow.set_frame_height(intValue);
-    log_info("Maslow frame height set to " << intValue);
+    log_info(M+" frame height set to " << intValue);
     return Error::Ok;
 }
 static Error maslow_safety_off(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
@@ -1165,40 +1165,40 @@ void make_user_commands() {
     new UserCommand("30", "FakeMaxSpindleSpeed", fakeMaxSpindleSpeed, notIdleOrAlarm);
     new UserCommand("32", "FakeLaserMode", fakeLaserMode, notIdleOrAlarm);
     //Maslow-specific commands
-    new UserCommand("TL", "Maslow/retractTL", maslow_retract_TL, anyState);
-    new UserCommand("TR", "Maslow/retractTR", maslow_retract_TR, anyState);
-    new UserCommand("BR", "Maslow/retractBR", maslow_retract_BR, anyState);
-    new UserCommand("BL", "Maslow/retractBL", maslow_retract_BL, anyState);
-    new UserCommand("ALL", "Maslow/retract", maslow_retract_ALL, anyState);
-    new UserCommand("EXT", "Maslow/extend", maslow_extend_ALL, anyState);
-    new UserCommand("TELEMDUMP", "Maslow/telemetryDump", maslow_telemetry_dump, anyState);
-    new UserCommand("TELEM", "Maslow/setTelemetry", maslow_telemetry_set, anyState);
-    new UserCommand("CMP", "Maslow/comply", maslow_set_comply, anyState);
-    new UserCommand("CAL", "Maslow/calibrate", maslow_start_calibration, anyState);
+    new UserCommand("TL", M+"/retractTL", maslow_retract_TL, anyState);
+    new UserCommand("TR", M+"/retractTR", maslow_retract_TR, anyState);
+    new UserCommand("BR", M+"/retractBR", maslow_retract_BR, anyState);
+    new UserCommand("BL", M+"/retractBL", maslow_retract_BL, anyState);
+    new UserCommand("ALL", M+"/retract", maslow_retract_ALL, anyState);
+    new UserCommand("EXT", M+"/extend", maslow_extend_ALL, anyState);
+    new UserCommand("TELEMDUMP", M+"/telemetryDump", maslow_telemetry_dump, anyState);
+    new UserCommand("TELEM", M+"/setTelemetry", maslow_telemetry_set, anyState);
+    new UserCommand("CMP", M+"/comply", maslow_set_comply, anyState);
+    new UserCommand("CAL", M+"/calibrate", maslow_start_calibration, anyState);
 
-    new UserCommand("TLI", "Maslow/calibrateTLI", maslow_TLI, anyState);
-    new UserCommand("TRI", "Maslow/calibrateTRI", maslow_TRI, anyState);
-    new UserCommand("BRI", "Maslow/calibrateBRI", maslow_BRI, anyState);
-    new UserCommand("BLI", "Maslow/calibrateBLI", maslow_BLI, anyState);
+    new UserCommand("TLI", M+"/calibrateTLI", maslow_TLI, anyState);
+    new UserCommand("TRI", M+"/calibrateTRI", maslow_TRI, anyState);
+    new UserCommand("BRI", M+"/calibrateBRI", maslow_BRI, anyState);
+    new UserCommand("BLI", M+"/calibrateBLI", maslow_BLI, anyState);
 
-    new UserCommand("TLO", "Maslow/calibrateTLO", maslow_TLO, anyState);
-    new UserCommand("TRO", "Maslow/calibrateTRO", maslow_TRO, anyState);
-    new UserCommand("BRO", "Maslow/calibrateBRO", maslow_BRO, anyState);
-    new UserCommand("BLO", "Maslow/calibrateBLO", maslow_BLO, anyState);
+    new UserCommand("TLO", M+"/calibrateTLO", maslow_TLO, anyState);
+    new UserCommand("TRO", M+"/calibrateTRO", maslow_TRO, anyState);
+    new UserCommand("BRO", M+"/calibrateBRO", maslow_BRO, anyState);
+    new UserCommand("BLO", M+"/calibrateBLO", maslow_BLO, anyState);
 
     new UserCommand("CO", "Config/Overwrite", overwrite_config, anyState);
 
-    new UserCommand("STOP", "Maslow/stop", maslow_stop, anyState); // experimental
-    new UserCommand("WDT", "Maslow/width", maslow_set_width, anyState);
-    new UserCommand("HGT", "Maslow/height", maslow_set_height, anyState);
-    new UserCommand("SFON", "Maslow/safetyON", maslow_safety_on, anyState);
-    new UserCommand("SFOFF", "Maslow/safetyOFF", maslow_safety_off, anyState);
-    new UserCommand("TEST", "Maslow/test", maslow_test, anyState);
-    new UserCommand("TKSLK", "Maslow/takeSlack", maslow_takeSlack, anyState);
-    new UserCommand("ACKCAL", "Maslow/ackCalibration", maslow_ack_cal, anyState);
-    new UserCommand("ESTOP", "Maslow/estop", maslow_estop, anyState);
-    new UserCommand("SETZSTOP", "Maslow/setZStop", maslow_set_zStop, anyState);
-    new UserCommand("MINFO", "Maslow/getInfo", maslow_get_info, anyState);
+    new UserCommand("STOP", M+"/stop", maslow_stop, anyState); // experimental
+    new UserCommand("WDT", M+"/width", maslow_set_width, anyState);
+    new UserCommand("HGT", M+"/height", maslow_set_height, anyState);
+    new UserCommand("SFON", M+"/safetyON", maslow_safety_on, anyState);
+    new UserCommand("SFOFF", M+"/safetyOFF", maslow_safety_off, anyState);
+    new UserCommand("TEST", M+"/test", maslow_test, anyState);
+    new UserCommand("TKSLK", M+"/takeSlack", maslow_takeSlack, anyState);
+    new UserCommand("ACKCAL", M+"/ackCalibration", maslow_ack_cal, anyState);
+    new UserCommand("ESTOP", M+"/estop", maslow_estop, anyState);
+    new UserCommand("SETZSTOP", M+"/setZStop", maslow_set_zStop, anyState);
+    new UserCommand("MINFO", M+"/getInfo", maslow_get_info, anyState);
 };
 
 // normalize_key puts a key string into canonical form -
@@ -1386,7 +1386,7 @@ void settings_execute_startup() {
             // We have to copy this to a mutable array because
             // gc_execute_line modifies the line while parsing.
             char gcline[256];
-            strncpy(gcline, str.c_str(), 255);
+            strncpy(gcline, &str[0], 255);
             status_code = gc_execute_line(gcline);
             // Uart0 << ">" << gcline << ":";
             if (status_code != Error::Ok) {

--- a/FluidNC/src/Settings.h
+++ b/FluidNC/src/Settings.h
@@ -370,6 +370,12 @@ public:
                 permissions_t auth = WG) :
         Command(NULL, GRBLCMD, auth, grblName, name, cmdChecker),
         _action(action) {}
+    UserCommand(const char* grblName,
+                const std::string name,
+                Error (*action)(const char*, WebUI::AuthenticationLevel, Channel&),
+                bool (*cmdChecker)(),
+                permissions_t auth = WG) :
+        UserCommand(grblName, &name[0], action, cmdChecker, auth) {}
 
     Error action(char* value, WebUI::AuthenticationLevel auth_level, Channel& response);
 };


### PR DESCRIPTION
Standardizes (standardises) most usages of "Maslow" in various strings.

~Also standardises usage of `&somestring[0]` instead of `somestring.c_str()` when converting from `std::string` to `char *`~ - rolled this back out