### PR TITLE
Expose constants

### DIFF
--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -398,13 +398,12 @@ bool Maslow_::takeSlackFunc() {
     if(takeSlackState == 2){
         if (take_measurement_avg_with_check(0, UP)) {
 
-            double offset = _beltEndExtension + _armLength;
             double threshold = 15;
 
-            float diffTL = calibration_data[0][0] - offset - computeTL(0, 0, 0);
-            float diffTR = calibration_data[1][0] - offset - computeTR(0, 0, 0);
-            float diffBL = calibration_data[2][0] - offset - computeBL(0, 0, 0);
-            float diffBR = calibration_data[3][0] - offset - computeBR(0, 0, 0);
+            float diffTL = calibration_data[0][0] - measurementToXYPlane(computeTL(0, 0, 0), tlZ);
+            float diffTR = calibration_data[1][0] - measurementToXYPlane(computeTR(0, 0, 0), trZ);
+            float diffBL = calibration_data[2][0] - measurementToXYPlane(computeBL(0, 0, 0), blZ);
+            float diffBR = calibration_data[3][0] - measurementToXYPlane(computeBR(0, 0, 0), brZ);
             log_info("Center point deviation: TL: " << diffTL << " TR: " << diffTR << " BL: " << diffBL << " BR: " << diffBR);
             if (abs(diffTL) > threshold || abs(diffTR) > threshold || abs(diffBL) > threshold || abs(diffBR) > threshold) {
                 log_error("Center point deviation over " << threshold << "mm, your coordinate system is not accurate, maybe try running calibration again?");
@@ -975,13 +974,12 @@ bool Maslow_::take_measurement_avg_with_check(int waypoint, int dir) {
 
             //A check to see if the results on the first point are within the expected range
             if(waypoint == 0){
-                double offset = _beltEndExtension + _armLength;
                 double threshold = 100;
 
-                float diffTL = calibration_data[0][0] - offset - computeTL(0, 0, 0);
-                float diffTR = calibration_data[1][0] - offset - computeTR(0, 0, 0);
-                float diffBL = calibration_data[2][0] - offset - computeBL(0, 0, 0);
-                float diffBR = calibration_data[3][0] - offset - computeBR(0, 0, 0);
+                float diffTL = calibration_data[0][0] - measurementToXYPlane(computeTL(0, 0, 0), tlZ);
+                float diffTR = calibration_data[1][0] - measurementToXYPlane(computeTR(0, 0, 0), trZ);
+                float diffBL = calibration_data[2][0] - measurementToXYPlane(computeBL(0, 0, 0), blZ);
+                float diffBR = calibration_data[3][0] - measurementToXYPlane(computeBR(0, 0, 0), brZ);
                 log_info("Center point deviation: TL: " << diffTL << " TR: " << diffTR << " BL: " << diffBL << " BR: " << diffBR);
 
                 if (abs(diffTL) > threshold || abs(diffTR) > threshold || abs(diffBL) > threshold || abs(diffBR) > threshold) {

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -400,10 +400,10 @@ bool Maslow_::takeSlackFunc() {
 
             double threshold = 15;
 
-            float diffTL = calibration_data[0][0] - measurementToXYPlane(computeTL(0, 0, 0), tlZ);
-            float diffTR = calibration_data[1][0] - measurementToXYPlane(computeTR(0, 0, 0), trZ);
-            float diffBL = calibration_data[2][0] - measurementToXYPlane(computeBL(0, 0, 0), blZ);
-            float diffBR = calibration_data[3][0] - measurementToXYPlane(computeBR(0, 0, 0), brZ);
+            float diffTL = calibration_data[0][0] - measurementToXYPlane(computeTL(0, 0, targetZ), tlZ);
+            float diffTR = calibration_data[1][0] - measurementToXYPlane(computeTR(0, 0, targetZ), trZ);
+            float diffBL = calibration_data[2][0] - measurementToXYPlane(computeBL(0, 0, targetZ), blZ);
+            float diffBR = calibration_data[3][0] - measurementToXYPlane(computeBR(0, 0, targetZ), brZ);
             log_info("Center point deviation: TL: " << diffTL << " TR: " << diffTR << " BL: " << diffBL << " BR: " << diffBR);
             if (abs(diffTL) > threshold || abs(diffTR) > threshold || abs(diffBL) > threshold || abs(diffBR) > threshold) {
                 log_error("Center point deviation over " << threshold << "mm, your coordinate system is not accurate, maybe try running calibration again?");
@@ -737,9 +737,10 @@ float Maslow_::computeTL(float x, float y, float z) {
 //------------------------------------------------------
 
 //Takes a raw measurement, projects it into the XY plane, then adds the belt end extension and arm length to get the actual distance.
-float Maslow_::measurementToXYPlane(float measurement, float zHeight){
+float Maslow_::measurementToXYPlane(float measurement, float zbase){
 
-    float lengthInXY = sqrt(measurement * measurement - zHeight * zHeight);
+    float z = zbase + targetZ;
+    float lengthInXY = sqrt(measurement * measurement - z * z);
     return lengthInXY + _beltEndExtension + _armLength; //Add the belt end extension and arm length to get the actual distance
 }
 
@@ -976,10 +977,10 @@ bool Maslow_::take_measurement_avg_with_check(int waypoint, int dir) {
             if(waypoint == 0){
                 double threshold = 100;
 
-                float diffTL = calibration_data[0][0] - measurementToXYPlane(computeTL(0, 0, 0), tlZ);
-                float diffTR = calibration_data[1][0] - measurementToXYPlane(computeTR(0, 0, 0), trZ);
-                float diffBL = calibration_data[2][0] - measurementToXYPlane(computeBL(0, 0, 0), blZ);
-                float diffBR = calibration_data[3][0] - measurementToXYPlane(computeBR(0, 0, 0), brZ);
+                float diffTL = calibration_data[0][0] - measurementToXYPlane(computeTL(0, 0, targetZ), tlZ);
+                float diffTR = calibration_data[1][0] - measurementToXYPlane(computeTR(0, 0, targetZ), trZ);
+                float diffBL = calibration_data[2][0] - measurementToXYPlane(computeBL(0, 0, targetZ), blZ);
+                float diffBR = calibration_data[3][0] - measurementToXYPlane(computeBR(0, 0, targetZ), brZ);
                 log_info("Center point deviation: TL: " << diffTL << " TR: " << diffTR << " BL: " << diffBL << " BR: " << diffBR);
 
                 if (abs(diffTL) > threshold || abs(diffTR) > threshold || abs(diffBL) > threshold || abs(diffBR) > threshold) {

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -276,12 +276,12 @@ public:
     float brY;
     float brZ;
 
+    float _beltEndExtension = 30;  //Based on the CAD model these should add to 153.4
+    float _armLength        = 123.4;
+
 private:
     float centerX;
     float centerY;
-
-    float _beltEndExtension = 30;  //Based on the CAD model these should add to 153.4
-    float _armLength        = 123.4;
 
     //Used to keep track of how often the PID controller is updated
     unsigned long lastCallToPID    = millis();


### PR DESCRIPTION
This changes the arm length and belt anchor length from constants to variables with a default. I believe that this is all that is needed to allow them to be set through the current UI, but I do not have a setup to be able to verify this.

These should normally not change, it's only if someone makes custom anchors or custom arms that these values would be different. But we now have the maslow 4.1 in the works and a few people experimenting with full DIY setups, so I think it's time to start exposing this sort of thing