### PR TITLE
save arm position when idle, restore at startup

### DIFF
--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -124,9 +124,10 @@ public:
     float computeTR(float x, float y, float z);
     float computeTL(float x, float y, float z);
 
-    //Save and load z-axis position, set z-stop
-    void saveZPos();
-    void loadZPos();
+    //Save and load position, set z-stop
+    void savePos();
+    void loadPos();
+    bool saveToNvs(const char*, float, nvs_handle_t); //helper function
     /** Sets the 'bottom' Z position, this is a 'stop' beyond which travel cannot continue */
     void setZStop();
 

--- a/FluidNC/src/Maslow/MotorUnit.cpp
+++ b/FluidNC/src/Maslow/MotorUnit.cpp
@@ -271,6 +271,12 @@ double MotorUnit::getPosition() {
     return positionNow;
 }
 
+// Sets the current position of the axis in mm
+double MotorUnit::setPosition(double currentLength) {
+    mostRecentCumulativeEncoderReading = (currentLength * 4096.0 ) / _mmPerRevolution * -1;
+    return true;
+}
+
 // Returns the current motor power draw
 double MotorUnit::getCurrent() {
     return motor.readCurrent();

--- a/FluidNC/src/Maslow/MotorUnit.h
+++ b/FluidNC/src/Maslow/MotorUnit.h
@@ -20,6 +20,7 @@ public:
     void   setTarget(double newTarget);
     double getTarget();
     double getPosition();
+    double setPosition(double currentLength);
     double getCurrent();
     double getPositionError();
     void   stop();


### PR DESCRIPTION
fixes #93 #171 

disclaimer!!!

compile tested, but I don't have access to hardware from home to functional test this

I converted most of saveZPos to a helper function so that it's not opening and committing to the NVM for each variable, but I don't know enough about the nvm functions to be sure that this is safe

I created setPosition() in MotorUnit and gave it's parameters as a double because that's how values hare handled in that file, but in Maslow.cpp all the positions are handled as floats. I seem to remember that with the original maslow we needed to handle chain lengths as doubles or we ran into precision problems, but if that is the case, we have a lot to go through and change. I expect that FluidNC handles positions as mm floats, but it's not normally handling distances as large as the maslow