### PR TITLE
fix bad nvs multiple declaration

### DIFF
--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -1568,7 +1568,7 @@ void Maslow_::test_() {
 //This function saves the current z-axis position to the non-volitle storage
 void Maslow_::saveZPos() {
     nvs_handle_t nvsHandle;
-    esp_err_t ret = nvs_open(nvs, NVS_READWRITE, &nvsHandle);
+    esp_err_t ret = nvs_open("maslow", NVS_READWRITE, &nvsHandle);
     if (ret != ESP_OK) {
         log_info("Error " + std::string(esp_err_to_name(ret)) + " opening NVS handle!\n");
         return;
@@ -1608,7 +1608,7 @@ void Maslow_::saveZPos() {
 //This function loads the z-axis position from the non-volitle storage
 void Maslow_::loadZPos() {
     nvs_handle_t nvsHandle;
-    esp_err_t ret = nvs_open(nvs, NVS_READWRITE, &nvsHandle);
+    esp_err_t ret = nvs_open("maslow", NVS_READWRITE, &nvsHandle);
     if (ret != ESP_OK) {
         log_info("Error " + std::string(esp_err_to_name(ret)) + " opening NVS handle!\n");
         return;

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -28,7 +28,7 @@
 // Common Default strings - especially used by config
 const std::string M = "Maslow";
 // Non-volatile storage name
-const char * nvs = "maslow";
+//const char * nvs_t = "maslow";
 
 struct TelemetryFileHeader {
     unsigned int structureSize; // 4 bytes

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -226,7 +226,7 @@ public:
     //calibration stuff
 
     int frame_dimention_MIN = 400;
-    int frame_dimention_MAX = 5000;
+    int frame_dimention_MAX = 15000;
 
     double calibrationGrid[CALIBRATION_GRID_SIZE_MAX][2] = { 0 };
     float  calibration_grid_width_mm_X               = 2000;  // mm offset from the edge of the frame


### PR DESCRIPTION
the maslow name cleanup is causing compile errors, this reverts the nvs declaration and use to temporarily fix the problem