### PR TITLE
Expose constants

### DIFF
--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -119,6 +119,8 @@ namespace Machine {
         handler.item(M+"_Retract_Current_Threshold", Maslow.retractCurrentThreshold, 0, 3500);
         handler.item(M+"_Calibration_Current_Threshold", Maslow.calibrationCurrentThreshold, 0, 3500);
         handler.item(M+"_Acceptable_Calibration_Threshold", Maslow.acceptableCalibrationThreshold, 0, 1);
+	handler.item(M+"_beltEndExtension", Maslow._beltEndExtension);
+	handler.item(M+"_armLength", Maslow._armLength);
     }
 
     void MachineConfig::afterParse() {

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -1568,7 +1568,7 @@ void Maslow_::test_() {
 //This function saves the current z-axis position to the non-volitle storage
 void Maslow_::saveZPos() {
     nvs_handle_t nvsHandle;
-    esp_err_t ret = nvs_open(nvs, NVS_READWRITE, &nvsHandle);
+    esp_err_t ret = nvs_open("maslow", NVS_READWRITE, &nvsHandle);
     if (ret != ESP_OK) {
         log_info("Error " + std::string(esp_err_to_name(ret)) + " opening NVS handle!\n");
         return;
@@ -1608,7 +1608,7 @@ void Maslow_::saveZPos() {
 //This function loads the z-axis position from the non-volitle storage
 void Maslow_::loadZPos() {
     nvs_handle_t nvsHandle;
-    esp_err_t ret = nvs_open(nvs, NVS_READWRITE, &nvsHandle);
+    esp_err_t ret = nvs_open("maslow", NVS_READWRITE, &nvsHandle);
     if (ret != ESP_OK) {
         log_info("Error " + std::string(esp_err_to_name(ret)) + " opening NVS handle!\n");
         return;

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -281,12 +281,12 @@ public:
     float brY;
     float brZ;
 
+    float _beltEndExtension = 30;  //Based on the CAD model these should add to 153.4
+    float _armLength        = 123.4;
+
 private:
     float centerX;
     float centerY;
-
-    float _beltEndExtension = 30;  //Based on the CAD model these should add to 153.4
-    float _armLength        = 123.4;
 
     //Used to keep track of how often the PID controller is updated
     unsigned long lastCallToPID    = millis();

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -28,7 +28,7 @@
 // Common Default strings - especially used by config
 const std::string M = "Maslow";
 // Non-volatile storage name
-const char * nvs = "maslow";
+//const char * nvs_t = "maslow";
 
 struct TelemetryFileHeader {
     unsigned int structureSize; // 4 bytes


### PR DESCRIPTION
change _armLength and _beltEndExtension from private constants to config items (but if they are not defined, default to the values previously set as constants)

This supports people building non-standard systems (typically longer arms)