### PR TITLE
Reset setup complete after belts retracted

### DIFF
--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -1383,6 +1383,7 @@ void Maslow_::retractALL() {
     axisTR.reset();
     axisBL.reset();
     axisBR.reset();
+    setupIsComplete = false;
 }
 void Maslow_::extendALL() {
 


### PR DESCRIPTION
This catches the case where calibration has been completed and then the belts have been fully retracted and then the z-axis (or any other axis) is moved. Previously it would try to unspool the belts which is not what we want.