### PR TITLE
Free memory after calibration

### DIFF
--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -502,14 +502,13 @@ void Maslow_::allocateCalibrationMemory() {
 
 // Function to deallocate memory for calibration arrays
 void Maslow_::deallocateCalibrationMemory() {
-    return;
-    // delete[] calibrationGrid;
-    // calibrationGrid = nullptr;
-    // for (int i = 0; i < CALIBRATION_GRID_SIZE_MAX; ++i) {
-    //     delete[] calibration_data[i];
-    //     }
-    // delete[] calibration_data;
-    // calibration_data = nullptr;
+    delete[] calibrationGrid;
+    calibrationGrid = nullptr;
+    for (int i = 0; i < CALIBRATION_GRID_SIZE_MAX; ++i) {
+        delete[] calibration_data[i];
+        }
+    delete[] calibration_data;
+    calibration_data = nullptr;
 }
 
 //------------------------------------------------------
@@ -838,7 +837,7 @@ bool Maslow_::take_measurement(float result[4], int dir, int run) {
 
         //once both belts are pulled, take a measurement
         if (BR_tight && BL_tight) {
-            //take measurement and record it to the calibration data array. This should take a pointer to where to store the data
+            //take measurement and record it to the calibration data array.
             result[0] = measurementToXYPlane(axisTL.getPosition(), tlZ);
             result[1] = measurementToXYPlane(axisTR.getPosition(), trZ);
             result[2] = measurementToXYPlane(axisBL.getPosition(), blZ);
@@ -931,7 +930,7 @@ bool Maslow_::take_measurement(float result[4], int dir, int run) {
             }
         }
         if (pull1_tight && pull2_tight) {
-            //take measurement and record it to the calibration data array. This should take a pointer to where to store the data
+            //take measurement and record it to the calibration data array.
             result[0] = measurementToXYPlane(axisTL.getPosition(), tlZ);
             result[1] = measurementToXYPlane(axisTR.getPosition(), trZ);
             result[2] = measurementToXYPlane(axisBL.getPosition(), blZ);

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -446,13 +446,10 @@ void Maslow_::calibration_loop() {
     static int  direction             = UP;
     static bool measurementInProgress = false;
     if(waypoint > pointCount){
-        log_info("Thinks it's finished");
-        log_info("Waypoint: " << waypoint << " PointCount: " << pointCount);
         calibrationInProgress = false;
         waypoint              = 0;
         setupIsComplete       = true;
-        log_info("Calibration complete 447");
-        log_info("Dealocating calibration memory");
+        log_info("Calibration complete");
         deallocateCalibrationMemory();
         return;
     }
@@ -469,7 +466,6 @@ void Maslow_::calibration_loop() {
                 calibrationDataWaiting = millis();
                 sys.set_state(State::Idle);
                 recomputeCountIndex++;
-                debug_calibration_data();
             }
             else {
                 hold(250);
@@ -497,7 +493,6 @@ void Maslow_::calibration_loop() {
 
 // Function to allocate memory for calibration arrays
 void Maslow_::allocateCalibrationMemory() {
-    log_info("Allocating calibration memory");
     calibrationGrid = new float[CALIBRATION_GRID_SIZE_MAX][2];
     calibration_data = new float*[CALIBRATION_GRID_SIZE_MAX];
     for (int i = 0; i < CALIBRATION_GRID_SIZE_MAX; ++i) {
@@ -796,10 +791,6 @@ float Maslow_::measurementToXYPlane(float measurement, float zHeight){
  * @return True when the measurement is done, false otherwise.
  */
 bool Maslow_::take_measurement(float result[4], int dir, int run) {
-
-    if(random(1000) == 0) {
-        debug_calibration_data();
-    }
 
     //Shouldn't this be handled with the same code as below but with the direction set to UP?
     if (orientation == VERTICAL) {
@@ -1281,7 +1272,6 @@ bool Maslow_::checkValidMove(double fromX, double fromY, double toX, double toY)
 
 //The number of points high and wide  must be an odd number
 bool Maslow_::generate_calibration_grid() {
-    log_info("Generating calibration grid");
 
     //Allocate memory for the calibration grid
     allocateCalibrationMemory();
@@ -1810,7 +1800,6 @@ void Maslow_::checkCalibrationData() {
         if (millis() - calibrationDataWaiting > 30007) {
             log_error("Calibration data not acknowledged by computer, resending");
             print_calibration_data();
-            debug_calibration_data();
             calibrationDataWaiting = millis();
         }
     }
@@ -1819,19 +1808,6 @@ void Maslow_::checkCalibrationData() {
 // function for outputting calibration data in the log line by line like this: {bl:2376.69,   br:923.40,   tr:1733.87,   tl:2801.87},
 void Maslow_::print_calibration_data() {
     String data = "CLBM:[";
-    for (int i = 0; i < waypoint; i++) {
-        data += "{bl:" + String(calibration_data[i][2]) + ",   br:" + String(calibration_data[i][3]) +
-                ",   tr:" + String(calibration_data[i][1]) + ",   tl:" + String(calibration_data[i][0]) + "},";
-    }
-    data += "]";
-    HeartBeatEnabled = false;
-    log_data(data.c_str());
-    HeartBeatEnabled = true;
-}
-
-// function for outputting calibration data in the log line by line like this: {bl:2376.69,   br:923.40,   tr:1733.87,   tl:2801.87},
-void Maslow_::debug_calibration_data() {
-    String data = "Data:[";
     for (int i = 0; i < waypoint; i++) {
         data += "{bl:" + String(calibration_data[i][2]) + ",   br:" + String(calibration_data[i][3]) +
                 ",   tr:" + String(calibration_data[i][1]) + ",   tl:" + String(calibration_data[i][0]) + "},";

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -360,6 +360,7 @@ void Maslow_::home() {
     if(takeSlack){
         if (takeSlackFunc()) {
             takeSlack = false;
+            deallocateCalibrationMemory();
         }
     }
 
@@ -493,10 +494,14 @@ void Maslow_::calibration_loop() {
 
 // Function to allocate memory for calibration arrays
 void Maslow_::allocateCalibrationMemory() {
-    calibrationGrid = new float[CALIBRATION_GRID_SIZE_MAX][2];
-    calibration_data = new float*[CALIBRATION_GRID_SIZE_MAX];
-    for (int i = 0; i < CALIBRATION_GRID_SIZE_MAX; ++i) {
-        calibration_data[i] = new float[4];
+    if(calibrationGrid == nullptr){ //Check to prevent realocating
+        calibrationGrid = new float[CALIBRATION_GRID_SIZE_MAX][2];
+    }
+    if(calibration_data == nullptr){
+        calibration_data = new float*[CALIBRATION_GRID_SIZE_MAX];
+        for (int i = 0; i < CALIBRATION_GRID_SIZE_MAX; ++i) {
+            calibration_data[i] = new float[4];
+        }
     }
 }
 
@@ -1759,6 +1764,9 @@ void Maslow_::take_slack() {
     x         = 0;
     y         = 0;
     takeSlack = true;
+
+    //Alocate the memory to store the measurements in
+    allocateCalibrationMemory();
 }
 
 //------------------------------------------------------

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -228,7 +228,7 @@ public:
     int frame_dimention_MIN = 400;
     int frame_dimention_MAX = 15000;
 
-    double calibrationGrid[CALIBRATION_GRID_SIZE_MAX][2] = { 0 };
+    float  (*calibrationGrid)[2] = nullptr;
     float  calibration_grid_width_mm_X               = 2000;  // mm offset from the edge of the frame
     float  calibration_grid_height_mm_Y              = 1000;  // mm offset from the edge of the frame
     int    recomputePoints[10];                               // Stores the index of the points where we want to trigger a recompute
@@ -243,18 +243,19 @@ public:
     int    get_direction(double x, double y, double targetX, double targetY);
     bool   checkValidMove(double fromX, double fromY, double toX, double toY);
     bool   take_measurement_avg_with_check(int waypoint, int dir);
-    bool   take_measurement(int waypoint, int dir, int run);
+    bool   take_measurement(float result[4], int dir, int run);
     float  measurementToXYPlane(float measurement, float zHeight);
     bool   takeSlackFunc();
     void   test_();
     void   calibration_loop();
     void   print_calibration_data();
+    void   debug_calibration_data();
     void   calibrationDataRecieved();
     void   checkCalibrationData();
     void   reset_all_axis();
     bool   test = false;
     bool   orientation;
-    double calibration_data[4][CALIBRATION_GRID_SIZE_MAX] = { 0 };
+    float  **calibration_data = nullptr;
     int    pointCount                                 = 0;  //number of actual points in the grid,  < GRID_SIZE_MAX
     int    waypoint                                   = 0;  //The current waypoint in the calibration process
     int    calibrationGridSize                        = 9;
@@ -315,6 +316,8 @@ private:
     bool HeartBeatEnabled = true;
     void log_telem_hdr_csv();
     void log_telem_pt_csv(TelemetryData data);
+    void allocateCalibrationMemory();
+    void deallocateCalibrationMemory();
 };
 
 extern Maslow_& Maslow;

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -249,7 +249,6 @@ public:
     void   test_();
     void   calibration_loop();
     void   print_calibration_data();
-    void   debug_calibration_data();
     void   calibrationDataRecieved();
     void   checkCalibrationData();
     void   reset_all_axis();


### PR DESCRIPTION
This PR dynamically allocates memory to store values used in calibration during the calibration process. It should free up:

100*8*64 + 100*64 = 57600 bytes of memory outside of calibration and 57600/2 = 28800 bytes during calibration by switching from double to float for storing the results.
