### PR TITLE
Simplify calibration

### DIFF
--- a/FluidNC/data/maslow.yaml
+++ b/FluidNC/data/maslow.yaml
@@ -48,6 +48,8 @@ Maslow_Retract_Current_Threshold: 1300
 Maslow_Calibration_Current_Threshold: 1200
 # Sets the acceptable fitness threshold for moving on to the next calibration round.
 Maslow_Acceptable_Calibration_Threshold: 0.45
+# Sets the distance to extend the bels during the calibration process.
+Maslow_Extend_Dist: 1700
 
 
 ####################

--- a/FluidNC/src/Machine/MachineConfig.cpp
+++ b/FluidNC/src/Machine/MachineConfig.cpp
@@ -119,6 +119,7 @@ namespace Machine {
         handler.item(M+"_Retract_Current_Threshold", Maslow.retractCurrentThreshold, 0, 3500);
         handler.item(M+"_Calibration_Current_Threshold", Maslow.calibrationCurrentThreshold, 0, 3500);
         handler.item(M+"_Acceptable_Calibration_Threshold", Maslow.acceptableCalibrationThreshold, 0, 1);
+        handler.item(M+"_Extend_Dist", Maslow.extendDist, 0, 4250);
 	handler.item(M+"_beltEndExtension", Maslow._beltEndExtension);
 	handler.item(M+"_armLength", Maslow._armLength);
     }

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -490,7 +490,7 @@ void Maslow_::calibration_loop() {
             
             log_info("Moved with slack complete to " << calibrationGrid[waypoint][0] << " " << calibrationGrid[waypoint][1]);
             log_info("About to take a measurement");
-            
+
             measurementInProgress = true;
             direction             = get_direction(calibrationGrid[waypoint - 1][0],
                                       calibrationGrid[waypoint - 1][1],
@@ -1119,12 +1119,12 @@ bool Maslow_::take_measurement_avg_with_check(int waypoint, int dir) {
                 log_info("Machine Position found as X: " << x << " Y: " << y);
 
                 //Recompute the first four waypoint locations based on the current position
-                calibrationGrid[1][0] = x - 100;
+                calibrationGrid[1][0] = x + 100;
                 calibrationGrid[1][1] = y;
-                calibrationGrid[2][0] = x - 100;
-                calibrationGrid[2][1] = y - 100;
+                calibrationGrid[2][0] = x + 100;
+                calibrationGrid[2][1] = y + 100;
                 calibrationGrid[3][0] = x;
-                calibrationGrid[3][1] = y - 100;
+                calibrationGrid[3][1] = y + 100;
 
                 double threshold = 100;
                 float diffTL = measurements[0][0] - measurementToXYPlane(computeTL(x, y, 0), tlZ);
@@ -1472,6 +1472,7 @@ bool Maslow_::generate_calibration_grid() {
     //The point in the center
     calibrationGrid[pointCount][0] = 0;
     calibrationGrid[pointCount][1] = 0;
+    recomputePoints[0] = 4;
     pointCount++;
 
     int maxX = 1;
@@ -1480,7 +1481,7 @@ bool Maslow_::generate_calibration_grid() {
     int currentX = 0;
     int currentY = -1;
 
-    recomputeCount = 0;
+    recomputeCount = 1;
 
 
     while(maxX <= numberOfCycles){ //4 produces a 9x9 grid

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -1663,6 +1663,8 @@ void Maslow_::runCalibration() {
     gc_sync_position();//This updates the Gcode engine with the new position from the stepping engine that we set with set_motor_steps
     plan_sync_position();
 
+    updateCenterXY();
+
     sys.set_state(State::Homing);
 
     calibrationInProgress = true;

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -465,7 +465,6 @@ void Maslow_::calibration_loop() {
             waypoint++;  //Increment the waypoint counter
 
             if (waypoint > recomputePoints[recomputeCountIndex]) {  //If we have reached the end of this stage of the calibration process
-                log_info("Recompute point reached, sending the data to the UI");
                 calibrationInProgress = false;
                 print_calibration_data();
                 calibrationDataWaiting = millis();
@@ -782,7 +781,7 @@ float Maslow_::measurementToXYPlane(float measurement, float zHeight){
 }
 
 /*
-*Computes the current x cordinate of the sled based on the lengths of the upper two belts
+*Computes the current xy cordinates of the sled based on the lengths of the upper two belts
 */
 bool Maslow_::computeXYfromLengths(double TL, double TR, float &x, float &y) {
     double tlLength = TL;//measurementToXYPlane(TL, tlZ);
@@ -1133,12 +1132,6 @@ bool Maslow_::take_measurement_avg_with_check(int waypoint, int dir) {
                     freeMeasurements();
                     return false;
                 }
-                // float* mpos = get_mpos();
-                // mpos[0] = x;
-                // mpos[1] = y;
-                // set_motor_steps_from_mpos(mpos);
-                // gc_sync_position();//This updates the Gcode engine with the new position from the stepping engine that we set with set_motor_steps
-                // plan_sync_position();
 
                 log_info("Machine Position computed as X: " << x << " Y: " << y);
 
@@ -1236,9 +1229,6 @@ bool Maslow_::move_with_slack(double fromX, double fromY, double toX, double toY
 
         //Set the target to the starting position
         setTargets(fromX, fromY, 0);
-
-        // log_info("BL Extending: " << blExtending << " BR Extending: " << brExtending << " TL Extending: " << tlExtending << " TR Extending: " << trExtending);
-        // log_info("X Step Size: " << xStepSize << " Y Step Size: " << yStepSize);
     }
 
     //Decompress belts for 500ms...this happens by returning right away before running any of the rest of the code
@@ -1570,7 +1560,6 @@ void Maslow_::extendALL() {
 * This function is called once when calibration is started
 */
 void Maslow_::runCalibration() {
-    log_info("Starting calibration");
 
     //If we are at the first point we need to generate the grid before we can start
     if (waypoint == 0) {
@@ -1863,18 +1852,6 @@ void Maslow_::setZStop() {
     plan_sync_position();
 }
 
-
-
-// void Maslow_::set_frame_width(double width) {
-//     trX = width;
-//     brX = width;
-//     updateCenterXY();
-// }
-// void Maslow_::set_frame_height(double height) {
-//     tlY = height;
-//     trY = height;
-//     updateCenterXY();
-// }
 void Maslow_::take_slack() {
     //if not all axis are homed, we can't take the slack up
     if (!allAxisExtended()) {
@@ -1968,6 +1945,7 @@ void Maslow_::checkCalibrationData() {
 
 // function for outputting calibration data in the log line by line like this: {bl:2376.69,   br:923.40,   tr:1733.87,   tl:2801.87},
 void Maslow_::print_calibration_data() {
+    //These are used to set the browser side initial guess for the frame size
     log_data("$/" << M << "_tlX=" << tlX);
     log_data("$/" << M << "_tlY=" << tlY);
     log_data("$/" << M << "_trX=" << trX);

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -1410,7 +1410,7 @@ bool Maslow_::adjustFrameSizeToMatchFirstMeasurement() {
     //Check that we are in fact on the center line. The math assumes that we are roughly centered on the frame and so
     //the topleft and topright measurements should be roughly the same. It doesn't need to be exact.
     if (std::abs(tlLen - trLen) > 20) {
-        log_error("Unable to adjust frame size. Not centered.");
+        log_error("Unable to adjust frame size. Not centered."); //There exists a more generalized solution which should be implimented here: https://math.stackexchange.com/questions/5013127/find-square-size-from-inscribed-triangles?noredirect=1#comment10752043_5013127
         return false;
     }
 

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -319,18 +319,16 @@ void Maslow_::home() {
         //then make all the belts comply until they are extended fully, or user terminates it
         else {
             if (!extendedTL)
-                extendedTL = axisTL.extend(computeBL(0, 0, 0));
+                extendedTL = axisTL.extend(extendDist);
             if (!extendedTR)
-                extendedTR = axisTR.extend(computeBL(0, 0, 0));
+                extendedTR = axisTR.extend(extendDist);
             if (!extendedBL)
-                extendedBL = axisBL.extend(computeBL(0, 300, 0));
+                extendedBL = axisBL.extend(extendDist);
             if (!extendedBR)
-                extendedBR = axisBR.extend(computeBL(0, 300, 0));
+                extendedBR = axisBR.extend(extendDist);
             if (extendedTL && extendedTR && extendedBL && extendedBR) {
                 extendingALL = false;
-                //log_info("All belts extended to " << extendDist << "mm");
-                log_info("TL Extended To: " << computeBL(0, 0, 0));
-                log_info("TR Extended To: " << computeBL(0, 0, 0));
+                log_info("All belts extended to " << extendDist << "mm");
             }
         }
     }
@@ -429,6 +427,19 @@ bool Maslow_::takeSlackFunc() {
                 takeSlackState = 3;
                 holdTimer = millis();
                 setupIsComplete = true;
+
+                int zAxis = 2;
+                float* mpos = get_mpos();
+                mpos[0] = x;
+                mpos[1] = y;
+                set_motor_steps_from_mpos(mpos);
+
+                log_info("Current machine position loaded as X: " << x << " Y: " << y );
+
+                gc_sync_position();//This updates the Gcode engine with the new position from the stepping engine that we set with set_motor_steps
+                plan_sync_position();
+
+                sys.set_state(State::Idle);
             }
         }
     }

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -319,16 +319,16 @@ void Maslow_::home() {
         //then make all the belts comply until they are extended fully, or user terminates it
         else {
             if (!extendedTL)
-                extendedTL = axisTL.extend(computeTL(0, 0, 0));
+                extendedTL = axisTL.extend(extendDist);
             if (!extendedTR)
-                extendedTR = axisTR.extend(computeTR(0, 0, 0));
+                extendedTR = axisTR.extend(extendDist);
             if (!extendedBL)
-                extendedBL = axisBL.extend(computeBL(0, 300, 0));
+                extendedBL = axisBL.extend(extendDist);
             if (!extendedBR)
-                extendedBR = axisBR.extend(computeBR(0, 300, 0));
+                extendedBR = axisBR.extend(extendDist);
             if (extendedTL && extendedTR && extendedBL && extendedBR) {
                 extendingALL = false;
-                log_info("All belts extended to center position");
+                log_info("All belts extended to" << extendDist << "mm");
             }
         }
     }

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -486,8 +486,6 @@ void Maslow_::calibration_loop() {
                             calibrationGrid[waypoint][0],
                             calibrationGrid[waypoint][1])) {
 
-            log_info("Moved with slack complete from " << calibrationGrid[waypoint - 1][0] << "," << calibrationGrid[waypoint - 1][1] << " to " << calibrationGrid[waypoint][0] << "," << calibrationGrid[waypoint][1]);
-
             measurementInProgress = true;
             direction             = get_direction(calibrationGrid[waypoint - 1][0],
                                       calibrationGrid[waypoint - 1][1],

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -1135,12 +1135,12 @@ bool Maslow_::take_measurement_avg_with_check(int waypoint, int dir) {
                     freeMeasurements();
                     return false;
                 }
-                float* mpos = get_mpos();
-                mpos[0] = x;
-                mpos[1] = y;
-                set_motor_steps_from_mpos(mpos);
-                gc_sync_position();//This updates the Gcode engine with the new position from the stepping engine that we set with set_motor_steps
-                plan_sync_position();
+                // float* mpos = get_mpos();
+                // mpos[0] = x;
+                // mpos[1] = y;
+                // set_motor_steps_from_mpos(mpos);
+                // gc_sync_position();//This updates the Gcode engine with the new position from the stepping engine that we set with set_motor_steps
+                // plan_sync_position();
 
                 log_info("Machine Position found as X: " << x << " Y: " << y);
 
@@ -1243,8 +1243,8 @@ bool Maslow_::move_with_slack(double fromX, double fromY, double toX, double toY
         setTargets(fromX, fromY, 0);
 
         log_info("Moving from " << fromX << "," << fromY << " to " << toX << "," << toY);
-        log_info("BL Extending: " << blExtending << " BR Extending: " << brExtending << " TL Extending: " << tlExtending << " TR Extending: " << trExtending);
-        log_info("X Step Size: " << xStepSize << " Y Step Size: " << yStepSize);
+        // log_info("BL Extending: " << blExtending << " BR Extending: " << brExtending << " TL Extending: " << tlExtending << " TR Extending: " << trExtending);
+        // log_info("X Step Size: " << xStepSize << " Y Step Size: " << yStepSize);
     }
 
     //Decompress belts for 500ms...this happens by returning right away before running any of the rest of the code
@@ -1290,11 +1290,6 @@ bool Maslow_::move_with_slack(double fromX, double fromY, double toX, double toY
 
         //Check to see if we have reached our target position
     if (abs(getTargetX() - toX) < 5 && abs(getTargetY() - toY) < 5) {
-
-        log_info("Reached target position");
-        log_info("Final position: " << getTargetX() << "," << getTargetY());
-        log_info("Final Target: " << toX << "," << toY);
-
         stopMotors();
         reset_all_axis();
         decompress = true;  //Reset for the next pass

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -1556,35 +1556,19 @@ void Maslow_::retractBR() {
 }
 void Maslow_::retractALL() {
 
-    float initialX = -100;
-    float initialY = 100;
-
-    float x = 100;
-    float y = 100;
-
-    double TLLength = computeTL(initialX,initialY,0);
-    double TRLength = computeTR(initialX,initialY,0);
-
-    log_info("TL: " << TLLength << " TR: " << TRLength);
-
-    computeXYfromLengths(TLLength, TRLength, x, y);
-
-    log_info("Computed XY: " << x << ", " << y);
-
+    retractingTL = true;
+    retractingTR = true;
+    retractingBL = true;
+    retractingBR = true;
+    complyALL    = false;
+    extendingALL = false;
+    axisTL.reset();
+    axisTR.reset();
+    axisBL.reset();
+    axisBR.reset();
+    setupIsComplete = false;
 }
 
-    // retractingTL = true;
-    // retractingTR = true;
-    // retractingBL = true;
-    // retractingBR = true;
-    // complyALL    = false;
-    // extendingALL = false;
-    // axisTL.reset();
-    // axisTR.reset();
-    // axisBL.reset();
-    // axisBR.reset();
-    // setupIsComplete = false;
-//}
 void Maslow_::extendALL() {
 
     if (!all_axis_homed()) {

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -1156,6 +1156,10 @@ bool Maslow_::take_measurement_avg_with_check(int waypoint, int dir) {
                 calibrationGrid[2][1] = y + 100;
                 calibrationGrid[3][0] = x;
                 calibrationGrid[3][1] = y + 100;
+                calibrationGrid[4][0] = x - 100;
+                calibrationGrid[4][1] = y + 100;
+                calibrationGrid[5][0] = x - 100;
+                calibrationGrid[5][1] = y;
                 
             }
 
@@ -1460,12 +1464,13 @@ bool Maslow_::generate_calibration_grid() {
             return false; // return false or handle error appropriately
     }
 
-    pointCount = 4; //The first four points are computed dynamically
+    pointCount = 6; //The first four points are computed dynamically
+    recomputePoints[0] = 5;
 
     //The point in the center
     calibrationGrid[pointCount][0] = 0;
     calibrationGrid[pointCount][1] = 0;
-    recomputePoints[0] = 3;
+
     pointCount++;
 
     int maxX = 1;

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -1150,15 +1150,15 @@ bool Maslow_::take_measurement_avg_with_check(int waypoint, int dir) {
                 //Recompute the first four waypoint locations based on the current position
                 calibrationGrid[0][0] = x;//This first point is never really used because we've already measured here, but it shouldn't be left undefined
                 calibrationGrid[0][1] = y;
-                calibrationGrid[1][0] = x + 100;
+                calibrationGrid[1][0] = x + 150;
                 calibrationGrid[1][1] = y;
-                calibrationGrid[2][0] = x + 100;
-                calibrationGrid[2][1] = y + 100;
+                calibrationGrid[2][0] = x + 150;
+                calibrationGrid[2][1] = y + 150;
                 calibrationGrid[3][0] = x;
-                calibrationGrid[3][1] = y + 100;
-                calibrationGrid[4][0] = x - 100;
-                calibrationGrid[4][1] = y + 100;
-                calibrationGrid[5][0] = x - 100;
+                calibrationGrid[3][1] = y + 150;
+                calibrationGrid[4][0] = x - 150;
+                calibrationGrid[4][1] = y + 150;
+                calibrationGrid[5][0] = x - 150;
                 calibrationGrid[5][1] = y;
                 
             }

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -2013,6 +2013,12 @@ void Maslow_::checkCalibrationData() {
 
 // function for outputting calibration data in the log line by line like this: {bl:2376.69,   br:923.40,   tr:1733.87,   tl:2801.87},
 void Maslow_::print_calibration_data() {
+    log_data("$/" << M << "_tlX=" << tlX);
+    log_data("$/" << M << "_tlY=" << tlY);
+    log_data("$/" << M << "_trX=" << trX);
+    log_data("$/" << M << "_trY=" << trY);
+    log_data("$/" << M << "_brX=" << brX);
+
     String data = "CLBM:[";
     for (int i = 0; i < waypoint; i++) {
         data += "{bl:" + String(calibration_data[i][2]) + ",   br:" + String(calibration_data[i][3]) +

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -140,10 +140,10 @@ public:
 
     void stopMotors();
 
-    void   retractTL();
-    void   retractTR();
-    void   retractBL();
-    void   retractBR();
+    // void   retractTL();
+    // void   retractTR();
+    // void   retractBL();
+    // void   retractBR();
     void   retractALL();
     void   extendALL();
     void   take_slack();
@@ -157,8 +157,8 @@ public:
     bool   allAxisExtended();
     bool   setupComplete();
     void   safety_control();
-    void   set_frame_width(double width);
-    void   set_frame_height(double height);
+    // void   set_frame_width(double width);
+    // void   set_frame_height(double height);
     void   update_frame_xyz();
     bool   axis_homed[4] = { false, false, false, false };
     bool   retractingTL  = false;
@@ -239,7 +239,7 @@ public:
     bool   error                                     = false;
     String errorMessage;
     bool   generate_calibration_grid();
-    void   printCalibrationGrid();
+    //void   printCalibrationGrid();
     bool   move_with_slack(double fromX, double fromY, double toX, double toY);
     int    get_direction(double x, double y, double targetX, double targetY);
     bool   checkValidMove(double fromX, double fromY, double toX, double toY);
@@ -261,7 +261,7 @@ public:
     int    pointCount                                 = 0;  //number of actual points in the grid,  < GRID_SIZE_MAX
     int    waypoint                                   = 0;  //The current waypoint in the calibration process
     int    calibrationGridSize                        = 9;
-    // //keep track of where Maslow actually is
+    // //keep track of where Maslow actually is...are these actually used anywhere?
     double x;
     double y;
 

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -261,7 +261,7 @@ public:
     int    pointCount                                 = 0;  //number of actual points in the grid,  < GRID_SIZE_MAX
     int    waypoint                                   = 0;  //The current waypoint in the calibration process
     int    calibrationGridSize                        = 9;
-    // //keep track of where Maslow actually is, lower left corner is 0,0
+    // //keep track of where Maslow actually is
     double x;
     double y;
 

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -213,6 +213,7 @@ public:
     int retractCurrentThreshold = 1300;
     int calibrationCurrentThreshold = 1300;
     float acceptableCalibrationThreshold = 0.5;
+    float extendDist = 1000;
 
     bool axisBLHomed;
     bool axisBRHomed;

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -247,6 +247,8 @@ public:
     bool   take_measurement(float result[4], int dir, int run, int current);
     float  measurementToXYPlane(float measurement, float zHeight);
     bool   takeSlackFunc();
+    bool   adjustFrameSizeToMatchFirstMeasurement();
+    bool   computeXYfromLengths(double TL, double TR, float &x, float &y);
     void   test_();
     void   calibration_loop();
     void   print_calibration_data();

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -242,7 +242,6 @@ public:
     //void   printCalibrationGrid();
     bool   move_with_slack(double fromX, double fromY, double toX, double toY);
     int    get_direction(double x, double y, double targetX, double targetY);
-    bool   checkValidMove(double fromX, double fromY, double toX, double toY);
     bool   take_measurement_avg_with_check(int waypoint, int dir);
     bool   take_measurement(float result[4], int dir, int run, int current);
     float  measurementToXYPlane(float measurement, float zHeight);

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -213,7 +213,7 @@ public:
     int retractCurrentThreshold = 1300;
     int calibrationCurrentThreshold = 1300;
     float acceptableCalibrationThreshold = 0.5;
-    float extendDist = 1000;
+    float extendDist = 1700;
 
     bool axisBLHomed;
     bool axisBRHomed;

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -140,10 +140,6 @@ public:
 
     void stopMotors();
 
-    // void   retractTL();
-    // void   retractTR();
-    // void   retractBL();
-    // void   retractBR();
     void   retractALL();
     void   extendALL();
     void   take_slack();
@@ -157,8 +153,6 @@ public:
     bool   allAxisExtended();
     bool   setupComplete();
     void   safety_control();
-    // void   set_frame_width(double width);
-    // void   set_frame_height(double height);
     void   update_frame_xyz();
     bool   axis_homed[4] = { false, false, false, false };
     bool   retractingTL  = false;
@@ -260,7 +254,7 @@ public:
     int    pointCount                                 = 0;  //number of actual points in the grid,  < GRID_SIZE_MAX
     int    waypoint                                   = 0;  //The current waypoint in the calibration process
     int    calibrationGridSize                        = 9;
-    // //keep track of where Maslow actually is...are these actually used anywhere?
+    // //keep track of where Maslow actually is
     double x;
     double y;
 

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -828,38 +828,38 @@ static Error showHeap(const char* value, WebUI::AuthenticationLevel auth_level, 
 
 
 */
-static Error maslow_retract_TL(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-    if(Maslow.using_default_config) {
-        return Error::ConfigurationInvalid;
-    }
-    sys.set_state(State::Homing);
-    Maslow.retractTL();
-    return Error::Ok;
-}
-static Error maslow_retract_TR(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-    if(Maslow.using_default_config) {
-        return Error::ConfigurationInvalid;
-    }
-    sys.set_state(State::Homing);
-    Maslow.retractTR();
-    return Error::Ok;
-}
-static Error maslow_retract_BR(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-    if(Maslow.using_default_config) {
-        return Error::ConfigurationInvalid;
-    }
-    sys.set_state(State::Homing);
-    Maslow.retractBR();
-    return Error::Ok;
-}
-static Error maslow_retract_BL(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-    if(Maslow.using_default_config) {
-        return Error::ConfigurationInvalid;
-    }
-    sys.set_state(State::Homing);
-    Maslow.retractBL();
-    return Error::Ok;
-}
+// static Error maslow_retract_TL(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+//     if(Maslow.using_default_config) {
+//         return Error::ConfigurationInvalid;
+//     }
+//     sys.set_state(State::Homing);
+//     Maslow.retractTL();
+//     return Error::Ok;
+// }
+// static Error maslow_retract_TR(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+//     if(Maslow.using_default_config) {
+//         return Error::ConfigurationInvalid;
+//     }
+//     sys.set_state(State::Homing);
+//     Maslow.retractTR();
+//     return Error::Ok;
+// }
+// static Error maslow_retract_BR(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+//     if(Maslow.using_default_config) {
+//         return Error::ConfigurationInvalid;
+//     }
+//     sys.set_state(State::Homing);
+//     Maslow.retractBR();
+//     return Error::Ok;
+// }
+// static Error maslow_retract_BL(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+//     if(Maslow.using_default_config) {
+//         return Error::ConfigurationInvalid;
+//     }
+//     sys.set_state(State::Homing);
+//     Maslow.retractBL();
+//     return Error::Ok;
+// }
 static Error maslow_retract_ALL(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
     if(Maslow.using_default_config) {
         return Error::ConfigurationInvalid;
@@ -996,55 +996,55 @@ static Error maslow_BRI(const char* value, WebUI::AuthenticationLevel auth_level
 }
 
 
-static Error maslow_set_width(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-    if(Maslow.using_default_config) {
-        return Error::ConfigurationInvalid;
-    }
-    if (!value) {
-        //double width = Maslow.frame_width;
-        //log_info(M+" frame width is " << width);
-        return Error::Ok;
-    }
-    char*    endptr;
-    uint32_t intValue = strtol(value, &endptr, 10);
+// static Error maslow_set_width(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+//     if(Maslow.using_default_config) {
+//         return Error::ConfigurationInvalid;
+//     }
+//     if (!value) {
+//         //double width = Maslow.frame_width;
+//         //log_info(M+" frame width is " << width);
+//         return Error::Ok;
+//     }
+//     char*    endptr;
+//     uint32_t intValue = strtol(value, &endptr, 10);
 
-    if (endptr == value || *endptr != '\0') {
-        return Error::BadNumberFormat;
-    }
+//     if (endptr == value || *endptr != '\0') {
+//         return Error::BadNumberFormat;
+//     }
 
-    if( intValue < Maslow.frame_dimention_MIN || intValue > Maslow.frame_dimention_MAX ){
-        log_error(M+" frame width must be between " << Maslow.frame_dimention_MIN << " and " << Maslow.frame_dimention_MAX);
-        return Error::BadNumberFormat;
-    }
-    Maslow.set_frame_width(intValue);
-    log_info(M+" frame width set to " << intValue);
-    return Error::Ok;
-}
+//     if( intValue < Maslow.frame_dimention_MIN || intValue > Maslow.frame_dimention_MAX ){
+//         log_error(M+" frame width must be between " << Maslow.frame_dimention_MIN << " and " << Maslow.frame_dimention_MAX);
+//         return Error::BadNumberFormat;
+//     }
+//     Maslow.set_frame_width(intValue);
+//     log_info(M+" frame width set to " << intValue);
+//     return Error::Ok;
+// }
 
-static Error maslow_set_height(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-    if(Maslow.using_default_config) {
-        return Error::ConfigurationInvalid;
-    }
-    if (!value) {
-        //double height = Maslow.frame_height;
-        //log_info(M+" frame height is " << height);
-        return Error::Ok;
-    }
-    char*    endptr;
-    uint32_t intValue = strtol(value, &endptr, 10);
+// static Error maslow_set_height(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
+//     if(Maslow.using_default_config) {
+//         return Error::ConfigurationInvalid;
+//     }
+//     if (!value) {
+//         //double height = Maslow.frame_height;
+//         //log_info(M+" frame height is " << height);
+//         return Error::Ok;
+//     }
+//     char*    endptr;
+//     uint32_t intValue = strtol(value, &endptr, 10);
 
-    if (endptr == value || *endptr != '\0') {
-        return Error::BadNumberFormat;
-    }
+//     if (endptr == value || *endptr != '\0') {
+//         return Error::BadNumberFormat;
+//     }
 
-    if( intValue < Maslow.frame_dimention_MIN || intValue > Maslow.frame_dimention_MAX ){
-        log_error(M+" frame height must be between " << Maslow.frame_dimention_MIN << " and " << Maslow.frame_dimention_MAX);
-        return Error::BadNumberFormat;
-    }
-    Maslow.set_frame_height(intValue);
-    log_info(M+" frame height set to " << intValue);
-    return Error::Ok;
-}
+//     if( intValue < Maslow.frame_dimention_MIN || intValue > Maslow.frame_dimention_MAX ){
+//         log_error(M+" frame height must be between " << Maslow.frame_dimention_MIN << " and " << Maslow.frame_dimention_MAX);
+//         return Error::BadNumberFormat;
+//     }
+//     Maslow.set_frame_height(intValue);
+//     log_info(M+" frame height set to " << intValue);
+//     return Error::Ok;
+// }
 static Error maslow_safety_off(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
     if(Maslow.using_default_config) {
         return Error::ConfigurationInvalid;
@@ -1165,10 +1165,10 @@ void make_user_commands() {
     new UserCommand("30", "FakeMaxSpindleSpeed", fakeMaxSpindleSpeed, notIdleOrAlarm);
     new UserCommand("32", "FakeLaserMode", fakeLaserMode, notIdleOrAlarm);
     //Maslow-specific commands
-    new UserCommand("TL", M+"/retractTL", maslow_retract_TL, anyState);
-    new UserCommand("TR", M+"/retractTR", maslow_retract_TR, anyState);
-    new UserCommand("BR", M+"/retractBR", maslow_retract_BR, anyState);
-    new UserCommand("BL", M+"/retractBL", maslow_retract_BL, anyState);
+    // new UserCommand("TL", M+"/retractTL", maslow_retract_TL, anyState);
+    // new UserCommand("TR", M+"/retractTR", maslow_retract_TR, anyState);
+    // new UserCommand("BR", M+"/retractBR", maslow_retract_BR, anyState);
+    // new UserCommand("BL", M+"/retractBL", maslow_retract_BL, anyState);
     new UserCommand("ALL", M+"/retract", maslow_retract_ALL, anyState);
     new UserCommand("EXT", M+"/extend", maslow_extend_ALL, anyState);
     new UserCommand("TELEMDUMP", M+"/telemetryDump", maslow_telemetry_dump, anyState);
@@ -1189,8 +1189,8 @@ void make_user_commands() {
     new UserCommand("CO", "Config/Overwrite", overwrite_config, anyState);
 
     new UserCommand("STOP", M+"/stop", maslow_stop, anyState); // experimental
-    new UserCommand("WDT", M+"/width", maslow_set_width, anyState);
-    new UserCommand("HGT", M+"/height", maslow_set_height, anyState);
+    // new UserCommand("WDT", M+"/width", maslow_set_width, anyState);
+    // new UserCommand("HGT", M+"/height", maslow_set_height, anyState);
     new UserCommand("SFON", M+"/safetyON", maslow_safety_on, anyState);
     new UserCommand("SFOFF", M+"/safetyOFF", maslow_safety_off, anyState);
     new UserCommand("TEST", M+"/test", maslow_test, anyState);

--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -822,44 +822,10 @@ static Error showHeap(const char* value, WebUI::AuthenticationLevel auth_level, 
 
 
 /*
-
-
               //////////  Maslow-specific user cmd functions  //////////////
-
-
 */
-// static Error maslow_retract_TL(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-//     if(Maslow.using_default_config) {
-//         return Error::ConfigurationInvalid;
-//     }
-//     sys.set_state(State::Homing);
-//     Maslow.retractTL();
-//     return Error::Ok;
-// }
-// static Error maslow_retract_TR(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-//     if(Maslow.using_default_config) {
-//         return Error::ConfigurationInvalid;
-//     }
-//     sys.set_state(State::Homing);
-//     Maslow.retractTR();
-//     return Error::Ok;
-// }
-// static Error maslow_retract_BR(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-//     if(Maslow.using_default_config) {
-//         return Error::ConfigurationInvalid;
-//     }
-//     sys.set_state(State::Homing);
-//     Maslow.retractBR();
-//     return Error::Ok;
-// }
-// static Error maslow_retract_BL(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-//     if(Maslow.using_default_config) {
-//         return Error::ConfigurationInvalid;
-//     }
-//     sys.set_state(State::Homing);
-//     Maslow.retractBL();
-//     return Error::Ok;
-// }
+
+
 static Error maslow_retract_ALL(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
     if(Maslow.using_default_config) {
         return Error::ConfigurationInvalid;
@@ -995,56 +961,6 @@ static Error maslow_BRI(const char* value, WebUI::AuthenticationLevel auth_level
     return Error::Ok;
 }
 
-
-// static Error maslow_set_width(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-//     if(Maslow.using_default_config) {
-//         return Error::ConfigurationInvalid;
-//     }
-//     if (!value) {
-//         //double width = Maslow.frame_width;
-//         //log_info(M+" frame width is " << width);
-//         return Error::Ok;
-//     }
-//     char*    endptr;
-//     uint32_t intValue = strtol(value, &endptr, 10);
-
-//     if (endptr == value || *endptr != '\0') {
-//         return Error::BadNumberFormat;
-//     }
-
-//     if( intValue < Maslow.frame_dimention_MIN || intValue > Maslow.frame_dimention_MAX ){
-//         log_error(M+" frame width must be between " << Maslow.frame_dimention_MIN << " and " << Maslow.frame_dimention_MAX);
-//         return Error::BadNumberFormat;
-//     }
-//     Maslow.set_frame_width(intValue);
-//     log_info(M+" frame width set to " << intValue);
-//     return Error::Ok;
-// }
-
-// static Error maslow_set_height(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
-//     if(Maslow.using_default_config) {
-//         return Error::ConfigurationInvalid;
-//     }
-//     if (!value) {
-//         //double height = Maslow.frame_height;
-//         //log_info(M+" frame height is " << height);
-//         return Error::Ok;
-//     }
-//     char*    endptr;
-//     uint32_t intValue = strtol(value, &endptr, 10);
-
-//     if (endptr == value || *endptr != '\0') {
-//         return Error::BadNumberFormat;
-//     }
-
-//     if( intValue < Maslow.frame_dimention_MIN || intValue > Maslow.frame_dimention_MAX ){
-//         log_error(M+" frame height must be between " << Maslow.frame_dimention_MIN << " and " << Maslow.frame_dimention_MAX);
-//         return Error::BadNumberFormat;
-//     }
-//     Maslow.set_frame_height(intValue);
-//     log_info(M+" frame height set to " << intValue);
-//     return Error::Ok;
-// }
 static Error maslow_safety_off(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
     if(Maslow.using_default_config) {
         return Error::ConfigurationInvalid;
@@ -1165,10 +1081,6 @@ void make_user_commands() {
     new UserCommand("30", "FakeMaxSpindleSpeed", fakeMaxSpindleSpeed, notIdleOrAlarm);
     new UserCommand("32", "FakeLaserMode", fakeLaserMode, notIdleOrAlarm);
     //Maslow-specific commands
-    // new UserCommand("TL", M+"/retractTL", maslow_retract_TL, anyState);
-    // new UserCommand("TR", M+"/retractTR", maslow_retract_TR, anyState);
-    // new UserCommand("BR", M+"/retractBR", maslow_retract_BR, anyState);
-    // new UserCommand("BL", M+"/retractBL", maslow_retract_BL, anyState);
     new UserCommand("ALL", M+"/retract", maslow_retract_ALL, anyState);
     new UserCommand("EXT", M+"/extend", maslow_extend_ALL, anyState);
     new UserCommand("TELEMDUMP", M+"/telemetryDump", maslow_telemetry_dump, anyState);


### PR DESCRIPTION
This week's update significantly changes the calibration process to be (hopefully) more reliable, accurate, and most of all user friendly. The system no-longer relies on an input initial guess for how large the frame is which was leading to a large number of issues. Now the system will automatically compute the frame size itself and calibrate automatically.

In place of entering the size of the frame, the system now just asks how much belt to extend. 

<img width="676" alt="image" src="https://github.com/user-attachments/assets/053bc607-86c0-451b-a9af-4686e3a9651a" />

This is the length of belt in mm that the machine will extend when the "Extend All" button is pushed. It does not need to be enough to exactly center the machine ont he frame or anything like that. It just needs to be more than enough to put the machine on the frame (although roughly centered is nice).

After that calibration will proceed normally with the machine using an initial 6 measurements points near its starting point to compute a rough approximation of the frame size and then from there it will proceed with the regular calibration process.

The system is also more robust to handling situations where the calibration process fails to find a good solution. The process will now automatically restart. We initially added this feature to make the system more robust to handling inaccurate starting conditions (because it is now working with a less good initial guess for the frame size), but an unintended consequence is that the overall accuracy seems to be improved.



This week’s firmware update also adds something else new. While every machine is mostly the same, every Maslow4 is attached to a different frame. One of the biggest factors which can influence the accuracy of Maslow 4 is flex in the frame. If the anchor points aren’t truly fixed in place then the math isn’t able to precisely determine the machine’s position.


To help get more insight into frame rigidity we’ve added an extra measurement during the calibration process. After taking the first measurement in the center of the sheet we take one more measurement in exactly the same spot, but this time we pull the belts a little bit harder. If there is no flex in the system we would expect both measurements to be identical, but if there is some flexibility when we pull harder the frame will flex and give us a different measurement.

The results will be presented like this:

```
[MSG:INFO: Measuring Frame Flex]
[MSG:INFO: Flex measurement: TLBR: 1.940 TRBL: 4.236]
```

It’s a bit experimental at the moment, but we would love feedback on if it is valuable information.

There might be some growing pains with this week's update because it's got a LOT of changes under the hood, but overall it feels like a great direction. As always, if you find any bugs let us know and we'll fix them!
