### PR TITLE
Fix release tension

### DIFF
--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -347,6 +347,10 @@ void Maslow_::home() {
             axisBR.comply();
         }
         else {
+            axisTL.stop();
+            axisTR.stop();
+            axisBL.stop();
+            axisBR.stop();
             complyALL = false;
         }
     }


### PR DESCRIPTION
Somehow the changes to the calibration process removed a call to stop the motors which was halting the motors movement when release tension is called leading to the machine continuing to move after the tension has been released. This fixes that bug.