### PR TITLE
update posix install scripts for s3 and utilize more flash

### DIFF
--- a/build-release.py
+++ b/build-release.py
@@ -6,13 +6,14 @@ from shutil import copy
 from zipfile import ZipFile, ZipInfo
 import subprocess, os, sys, shutil
 import urllib.request
+import certifi
 
 verbose = '-v' in sys.argv
 
 environ = dict(os.environ)
 
 platformio = r"C:\Users\bar\.platformio\penv\Scripts\platformio.exe"
-version = "0.78 "
+version = "0.78"
 os.chdir(os.path.dirname(os.path.realpath(r"C:\Users\bar\Documents\GitHub\FluidNC\.pio")))
 #change path to the project folder (the folder with platformio.ini)
 tag = "maslow4-"+version
@@ -93,7 +94,7 @@ for envName in ['wifi_s3']:
     shutil.copy(os.path.join('.pio', 'build', envName, 'firmware.elf'), os.path.join(relPath, envName + '-' + 'firmware.elf'))
 
 for platform in ['win64', 'posix']:
-    print("Creating zip file for ", platform)
+    print("Creating zip file for", platform)
     terseOSName = {
         'win64': 'win',
         'posix': 'posix',
@@ -182,7 +183,7 @@ for platform in ['win64', 'posix']:
         # Download and unzip from ESP repo
         ZipFileName = EspDir + '.zip'
         if not os.path.isfile(ZipFileName):
-            with urllib.request.urlopen(EspRepo + ZipFileName) as u:
+            with urllib.request.urlopen(EspRepo + ZipFileName, cafile=certifi.where()) as u:
                 open(ZipFileName, 'wb').write(u.read())
 
         if withEsptoolBinary[platform]:

--- a/install_scripts/linux-python3/install-fs.sh
+++ b/install_scripts/linux-python3/install-fs.sh
@@ -6,7 +6,7 @@ fi
 
 . ./tools.sh
 
-LocalFS="0x3d0000 wifi/spiffs.bin"
+LocalFS="0x5F0000 wifi/spiffs.bin"
 
 esptool_write $LocalFS
 

--- a/install_scripts/posix/full-install.sh
+++ b/install_scripts/posix/full-install.sh
@@ -1,10 +1,16 @@
 #!/bin/sh
 
+BuildType=wifi_s3
+LocalFS="0x3d0000 wifi_s3/littlefs.bin"
+
 if ! . ./tools.sh; then exit 1; fi
+
+esptool_erase
 
 if ! check_security; then exit 1; fi
 
-LocalFS="0x3d0000 wifi_s3/littlefs.bin"
 esptool_write $LocalFS
+
+install
 
 deactivate

--- a/install_scripts/posix/full-install.sh
+++ b/install_scripts/posix/full-install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 BuildType=wifi_s3
-LocalFS="0x3d0000 wifi_s3/littlefs.bin"
+LocalFS="0x5F0000 wifi_s3/littlefs.bin"
 
 if ! . ./tools.sh; then exit 1; fi
 

--- a/install_scripts/posix/full-install.sh
+++ b/install_scripts/posix/full-install.sh
@@ -5,9 +5,10 @@ LocalFS="0x5F0000 wifi_s3/littlefs.bin"
 
 if ! . ./tools.sh; then exit 1; fi
 
-esptool_erase
+# check_security runs in esptool_erase & install
+# if ! check_security; then exit 1; fi
 
-if ! check_security; then exit 1; fi
+esptool_erase
 
 esptool_write $LocalFS
 

--- a/install_scripts/posix/install-fs.sh
+++ b/install_scripts/posix/install-fs.sh
@@ -4,7 +4,7 @@ if ! . ./tools.sh; then exit 1; fi
 
 if ! check_security; then exit 1; fi
 
-LocalFS="0x3d0000 wifi_s3/littlefs.bin"
+LocalFS="0x5F0000 wifi_s3/littlefs.bin"
 esptool_write $LocalFS
 
 deactivate

--- a/install_scripts/posix/install-wifi_s3.sh
+++ b/install_scripts/posix/install-wifi_s3.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-BuildType=wifi
+BuildType=wifi_s3
 
 if ! . ./tools.sh; then exit 1; fi
 

--- a/install_scripts/posix/tools.sh
+++ b/install_scripts/posix/tools.sh
@@ -36,7 +36,7 @@ fi
 
 EsptoolPath=esptool.py
 
-BaseArgs="--chip esp32 --baud 230400"
+BaseArgs="--chip esp32s3 --baud 921600"
 
 SetupArgs="--before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size detect"
 
@@ -80,7 +80,7 @@ esptool_erase() {
     esptool_basic erase_flash
 }
 
-Bootloader="0x1000 ${BuildType}/bootloader.bin"
+Bootloader="0x0000 ${BuildType}/bootloader.bin"
 Bootapp="0xe000 common/boot_app0.bin"
 Firmware="0x10000 ${BuildType}/firmware.bin"
 Partitions="0x8000 ${BuildType}/partitions.bin"

--- a/install_scripts/win64/install-fs.bat
+++ b/install_scripts/win64/install-fs.bat
@@ -6,7 +6,7 @@ set EsptoolPath=win64\esptool.exe
 set BaseArgs=--chip esp32s3 --baud 921600
 set SetupArgs=--before default_reset --after hard_reset write_flash -z --flash_mode dio --flash_freq 80m --flash_size detect
 
-set LocalFS=0x3d0000 wifi_s3\littlefs.bin
+set LocalFS=0x5F0000 wifi_s3\littlefs.bin
 
 echo %EsptoolPath% %BaseArgs% %SetupArgs% %LocalFS%
 %EsptoolPath% %BaseArgs% %SetupArgs% %LocalFS%

--- a/max_littlefs.csv
+++ b/max_littlefs.csv
@@ -1,0 +1,7 @@
+# Name   ,Type ,SubType  ,Offset   ,Size     ,Flags
+nvs      ,data ,nvs      ,0x9000   ,0x5000   ,
+otadata  ,data ,ota      ,0xe000   ,0x2000   ,
+app0     ,app  ,ota_0    ,0x10000  ,0x2F0000 ,
+app1     ,app  ,ota_1    ,0x300000 ,0x2F0000 ,
+spiffs   ,data ,spiffs   ,0x5F0000 ,0x1F0000 ,
+coredump ,data ,coredump ,0x7E0000 ,64K

--- a/max_littlefs.csv
+++ b/max_littlefs.csv
@@ -3,5 +3,5 @@ nvs      ,data ,nvs      ,0x9000   ,0x5000   ,
 otadata  ,data ,ota      ,0xe000   ,0x2000   ,
 app0     ,app  ,ota_0    ,0x10000  ,0x2F0000 ,
 app1     ,app  ,ota_1    ,0x300000 ,0x2F0000 ,
-spiffs   ,data ,spiffs   ,0x5F0000 ,0x1F0000 ,
-coredump ,data ,coredump ,0x7E0000 ,64K
+spiffs   ,data ,spiffs   ,0x5F0000 ,0x200000 ,
+coredump ,data ,coredump ,0x7F0000 ,64K

--- a/platformio.ini
+++ b/platformio.ini
@@ -55,7 +55,7 @@ platform_packages =
 board_build.arduino.upstream_packages = no
 
 upload_speed = 921600
-board_build.partitions = min_littlefs.csv ; For 4M ESP32
+board_build.partitions = max_littlefs.csv ; For 8M ESP32s3
 board_build.filesystem = littlefs
 ; board_build.partitions = FluidNC/ld/esp32/app3M_spiffs1M_8MB.csv  ; For 8Meg ESP32
 ; board_build.partitions = FluidNC/ld/esp32/app3M_spiffs9M_16MB.csv ; For 16Meg ESP32


### PR DESCRIPTION
This gets the install script working on macOS. I need to be in a platformio terminal (platformio bug face in the sidebar, then quick access -> new terminal), then I can run `python build-release.py` to generate windows and posix targets.

running `sh full-install.sh` from within the zip archive successfully erases and flashes first revision board (green board with rj45 jacks). Will test on other boards when I get to them later today or tomorrow.