### PR TITLE
Better state transition names and allow changing extend distance after extending

### DIFF
--- a/FluidNC/src/Maslow/Calibration.cpp
+++ b/FluidNC/src/Maslow/Calibration.cpp
@@ -70,6 +70,11 @@ bool Calibration::requestStateChange(int newState){
                 extendingALL = true; //This should be replaced by state variables
                 sys.set_state(State::Homing);
 
+                extendedTL = false;
+                extendedTR = false;
+                extendedBL = false;
+                extendedBR = false;
+
                 updateCenterXY(); //Why is this needed here?
                 return true;
             }
@@ -178,7 +183,7 @@ bool Calibration::requestStateChange(int newState){
                 break;
             }
         case RELEASE_TENSION: //We can enter release tension only from READY_TO_CUT or EXTENDEDOUT
-            if(currentState == READY_TO_CUT || currentState == EXTENDEDOUT){
+            if(currentState == READY_TO_CUT || currentState == UNKNOWN){
                 currentState = RELEASE_TENSION;
                 complyCallTimer = millis();
                 retractingTL    = false;
@@ -302,6 +307,7 @@ void Calibration::home() {
                 complyALL = false;
                 sys.set_state(State::Idle);
                 setupIsComplete = false; //We've undone the setup so apply tension is needed before we can move
+                requestStateChange(UNKNOWN);
             }
             break;
         case CALIBRATION_IN_PROGRESS:

--- a/FluidNC/src/Maslow/Calibration.h
+++ b/FluidNC/src/Maslow/Calibration.h
@@ -161,5 +161,22 @@ private:
     bool safetyOn = true;
     bool HeartBeatEnabled = true;
 
+    //A structure to hold the state names
+    struct StateName {
+        int   state;
+        char* name;
+    };
+    StateName stateNames[10] = {
+        { UNKNOWN, "Unknown" },
+        { RETRACTING, "Retracting Belts" },
+        { RETRACTED, "Belts Retracted" },
+        { EXTENDING, "Extending Belts" },
+        { EXTENDEDOUT, "Belts Extended" },
+        { TAKING_SLACK, "Taking Slack" },
+        { CALIBRATION_IN_PROGRESS, "Calibrating" },
+        { READY_TO_CUT, "Ready To Cut" },
+        { RELEASE_TENSION, "Releasing Tension" }
+    };
+
 
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved logging now displays descriptive state names instead of numeric values during calibration.
  - Expanded allowed state transitions for calibration, providing more flexibility in workflow.

- **Bug Fixes**
  - Added detailed log messages to clarify reasons for failed state transitions.

- **Documentation**
  - Enhanced code comments to better describe calibration state changes and behavior.

- **Style**
  - Minor formatting improvements for better code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->