### PR TITLE
Always allow release tension

### DIFF
--- a/FluidNC/src/Maslow/Calibration.cpp
+++ b/FluidNC/src/Maslow/Calibration.cpp
@@ -182,7 +182,7 @@ bool Calibration::requestStateChange(int newState){
             else{
                 break;
             }
-        case RELEASE_TENSION: //We can enter release tension from any state
+        case RELEASE_TENSION: //We can enter release tension from any stable state (the machine is not currently performing an action)
             if(currentState == READY_TO_CUT || currentState == UNKNOWN || currentState == EXTENDEDOUT){
                 currentState = RELEASE_TENSION;
                 complyCallTimer = millis();

--- a/FluidNC/src/Maslow/Calibration.cpp
+++ b/FluidNC/src/Maslow/Calibration.cpp
@@ -182,8 +182,8 @@ bool Calibration::requestStateChange(int newState){
             else{
                 break;
             }
-        case RELEASE_TENSION: //We can enter release tension only from READY_TO_CUT or EXTENDEDOUT
-            if(currentState == READY_TO_CUT || currentState == UNKNOWN){
+        case RELEASE_TENSION: //We can enter release tension from any state
+            if(true){
                 currentState = RELEASE_TENSION;
                 complyCallTimer = millis();
                 retractingTL    = false;

--- a/FluidNC/src/Maslow/Calibration.cpp
+++ b/FluidNC/src/Maslow/Calibration.cpp
@@ -183,7 +183,7 @@ bool Calibration::requestStateChange(int newState){
                 break;
             }
         case RELEASE_TENSION: //We can enter release tension from any state
-            if(true){
+            if(currentState == READY_TO_CUT || currentState == UNKNOWN || currentState == EXTENDEDOUT){
                 currentState = RELEASE_TENSION;
                 complyCallTimer = millis();
                 retractingTL    = false;

--- a/FluidNC/src/Maslow/Calibration.cpp
+++ b/FluidNC/src/Maslow/Calibration.cpp
@@ -35,7 +35,7 @@ bool Calibration::requestStateChange(int newState){
     log_info("Requesting state change from " << stateNames[currentState].name << " to " << stateNames[newState].name);
 
     switch(newState){
-        case UNKNOWN: //We can enter unknown from any state
+        case UNKNOWN: //We can enter unknown from any stable state (the machine is not currently performing an action)
             currentState = UNKNOWN;
             return true;
         case RETRACTING: //We can enter retracting from any state


### PR DESCRIPTION
Allows release tension from any state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the logic for transitioning into the RELEASE_TENSION state during calibration, now allowing this transition from additional states for improved flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->