### PR TITLE
Use state instead of flag for ready to cut

### DIFF
--- a/FluidNC/src/Maslow/.coderabbit.yaml
+++ b/FluidNC/src/Maslow/.coderabbit.yaml
@@ -1,0 +1,137 @@
+language: en-US
+tone_instructions: 'Be as concise as possible.'
+early_access: false
+enable_free_tier: true
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: false
+  high_level_summary_placeholder: '@coderabbitai summary'
+  high_level_summary_in_walkthrough: false
+  auto_title_placeholder: '@coderabbitai'
+  auto_title_instructions: ''
+  review_status: true
+  commit_status: true
+  fail_commit_status: false
+  collapse_walkthrough: true
+  changed_files_summary: false
+  sequence_diagrams: false
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  auto_apply_labels: false
+  suggested_reviewers: true
+  auto_assign_reviewers: false
+  poem: false
+  labeling_instructions: []
+  path_filters: []
+  path_instructions: []
+  abort_on_close: true
+  disable_cache: false
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    ignore_title_keywords: []
+    labels: []
+    drafts: false
+    base_branches: []
+  finishing_touches:
+    docstrings:
+      enabled: true
+  tools:
+    ast-grep:
+      rule_dirs: []
+      util_dirs: []
+      essential_rules: true
+      packages: []
+    shellcheck:
+      enabled: true
+    ruff:
+      enabled: true
+    markdownlint:
+      enabled: true
+    github-checks:
+      enabled: true
+      timeout_ms: 90000
+    languagetool:
+      enabled: true
+      enabled_rules: []
+      disabled_rules: []
+      enabled_categories: []
+      disabled_categories: []
+      enabled_only: false
+      level: default
+    biome:
+      enabled: true
+    hadolint:
+      enabled: true
+    swiftlint:
+      enabled: true
+    phpstan:
+      enabled: true
+      level: default
+    golangci-lint:
+      enabled: true
+    yamllint:
+      enabled: true
+    gitleaks:
+      enabled: true
+    checkov:
+      enabled: true
+    detekt:
+      enabled: true
+    eslint:
+      enabled: true
+    rubocop:
+      enabled: true
+    buf:
+      enabled: true
+    regal:
+      enabled: true
+    actionlint:
+      enabled: true
+    pmd:
+      enabled: true
+    cppcheck:
+      enabled: true
+    semgrep:
+      enabled: true
+    circleci:
+      enabled: true
+    sqlfluff:
+      enabled: true
+    prismaLint:
+      enabled: true
+    oxc:
+      enabled: true
+    shopifyThemeCheck:
+      enabled: true
+chat:
+  auto_reply: true
+  create_issues: true
+  integrations:
+    jira:
+      usage: auto
+    linear:
+      usage: auto
+knowledge_base:
+  opt_out: false
+  web_search:
+    enabled: true
+  learnings:
+    scope: auto
+  issues:
+    scope: auto
+  jira:
+    usage: auto
+    project_keys: []
+  linear:
+    usage: auto
+    team_keys: []
+  pull_requests:
+    scope: auto
+code_generation:
+  docstrings:
+    language: en-US
+    path_instructions: []

--- a/FluidNC/src/Maslow/Calibration.cpp
+++ b/FluidNC/src/Maslow/Calibration.cpp
@@ -1335,11 +1335,6 @@ bool Calibration::allAxisExtended() {
     return extendedTL && extendedTR && extendedBL && extendedBR;
 }
 
-// True if calibration is complete or take slack has been run
-bool Calibration::setupComplete() {
-    return setupIsComplete;
-}
-
 bool Calibration::checkOverides(){
     if(TLIOveride || TRIOveride || BLIOveride || BRIOveride || TLOOveride || TROOveride || BLOOveride || BROOveride){
         return true;

--- a/FluidNC/src/Maslow/Calibration.cpp
+++ b/FluidNC/src/Maslow/Calibration.cpp
@@ -59,7 +59,6 @@ bool Calibration::requestStateChange(int newState){
             Maslow.axisTR.reset();
             Maslow.axisBL.reset();
             Maslow.axisBR.reset();
-            setupIsComplete = false;
 
             success =  true;
             break;
@@ -328,7 +327,6 @@ void Calibration::home() {
                 Maslow.axisBR.stop();
                 complyALL = false;
                 sys.set_state(State::Idle);
-                setupIsComplete = false; //We've undone the setup so apply tension is needed before we can move
                 requestStateChange(UNKNOWN);
             }
             break;
@@ -358,7 +356,6 @@ void Calibration::calibration_loop() {
     if(waypoint > pointCount){ //Point count is the total number of points to measure so if waypoint > pointcount then the overall measurement process is complete
         calibrationInProgress = false;
         waypoint              = 0;
-        setupIsComplete       = true;
         log_info("Calibration complete");
         deallocateCalibrationMemory();
         requestStateChange(READY_TO_CUT);
@@ -452,7 +449,6 @@ bool Calibration::takeSlackFunc() {
                 log_info("Center point deviation within " << threshold << "mm, your coordinate system is accurate");
                 takeSlackState = 0;
                 holdTimer = millis();
-                setupIsComplete = true;
 
                 log_info("Current machine position loaded as X: " << x << " Y: " << y );
 

--- a/FluidNC/src/Maslow/Calibration.h
+++ b/FluidNC/src/Maslow/Calibration.h
@@ -27,7 +27,6 @@ public:
 
     bool   all_axis_homed();
     bool   allAxisExtended();
-    bool   setupComplete();
     void   safety_control();
     void   update_frame_xyz();
 

--- a/FluidNC/src/Maslow/Calibration.h
+++ b/FluidNC/src/Maslow/Calibration.h
@@ -119,7 +119,6 @@ private:
     bool extendedBR                  = false;
     bool extendingALL                = false;  //This is replaced by the state machine. Delete
     bool complyALL                   = false;
-    bool setupIsComplete             = false; //This should be replaced by the state machine
 
 
     //Variables used by take slack

--- a/FluidNC/src/Maslow/Maslow.cpp
+++ b/FluidNC/src/Maslow/Maslow.cpp
@@ -170,7 +170,7 @@ void Maslow_::update() {
                               steps_to_mpos(get_axis_motor_steps(2), 2));
 
             //This disables the belt motors until the user has completed calibration or apply tension and they have succeded
-            if (calibration.setupComplete()) {
+            if (calibration.currentState == READY_TO_CUT) {
                 Maslow.recomputePID();
             }
         }

--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -157,8 +157,6 @@ public:
 
     bool safetyOn = true;
 
-    bool setupIsComplete = false;
-
     Calibration calibration;
 
     void getInfo();


### PR DESCRIPTION
This PR is a response to this issue: https://forums.maslowcnc.com/t/m4-1-not-moving-after-loading-v1-05/24012/7?u=bar

The machine was maintaining two separate state flags for if it was ready to move and they could get out of sync causing the machine to report that it was ready to move but then not move. There should only be one place that this state is maintained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated calibration state handling to trigger PID updates only when calibration is in the "READY_TO_CUT" state.
  - Removed the setup completion check from the calibration process.

- **User Impact**
  - Calibration and PID updates are now more tightly controlled, potentially improving reliability during machine setup and operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->