### PR TITLE
Make fan turn off after setting z-home

### DIFF
--- a/FluidNC/src/ProcessSettings.cpp
+++ b/FluidNC/src/ProcessSettings.cpp
@@ -1019,6 +1019,7 @@ static Error maslow_estop(const char* value, WebUI::AuthenticationLevel auth_lev
 static Error maslow_set_zStop(const char* value, WebUI::AuthenticationLevel auth_level, Channel& out) {
     sys.set_state(State::Homing);
     Maslow.setZStop();
+    sys.set_state(State::Idle);
     return Error::Ok;
 }
 


### PR DESCRIPTION
Returns the machine to idle state after setting the z-axis home position so that the fan goes off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved system state handling after Z-stop operations to ensure the system returns to an idle state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->