### PR TITLE
Enable soft limits

### DIFF
--- a/FluidNC/data/maslow.yaml
+++ b/FluidNC/data/maslow.yaml
@@ -14,6 +14,8 @@ Maslow_Scale_Y: 1.000000
 Maslow_debugEnabled: false
 MaslowAutoUpdate: false
 MaslowUpdateURL: https://api.github.com/repos/BarbourSmith/FluidNC/releases/latest
+Maslow_spoilboardThickness: 0.000000
+Maslow_workThickness: 0.000000
 stepping: 
   engine: Timed
   idle_ms: 240
@@ -57,6 +59,7 @@ kinematics:
     beltEndExtension: 30.000000
     armLength: 123.400002
     maxSegmentLength: 5.000000
+    fixedZ: false
 
 axes: 
   shared_stepper_disable_pin: NO_PIN
@@ -65,8 +68,8 @@ axes:
     steps_per_mm: 80.000000
     max_rate_mm_per_min: 2000.000000
     acceleration_mm_per_sec2: 50.000000
-    max_travel_mm: 5000.000000
-    soft_limits: false
+    max_travel_mm: 4000.000000
+    soft_limits: true
     homing: 
       cycle: -1
       allow_single_axis: true
@@ -90,8 +93,8 @@ axes:
     steps_per_mm: 80.000000
     max_rate_mm_per_min: 2000.000000
     acceleration_mm_per_sec2: 50.000000
-    max_travel_mm: 5000.000000
-    soft_limits: false
+    max_travel_mm: 4000.000000
+    soft_limits: true
     homing: 
       cycle: -1
       allow_single_axis: true
@@ -115,8 +118,8 @@ axes:
     steps_per_mm: 80.000000
     max_rate_mm_per_min: 2000.000000
     acceleration_mm_per_sec2: 50.000000
-    max_travel_mm: 5000.000000
-    soft_limits: false
+    max_travel_mm: 4000.000000
+    soft_limits: true
     homing: 
       cycle: -1
       allow_single_axis: true
@@ -140,8 +143,8 @@ axes:
     steps_per_mm: 80.000000
     max_rate_mm_per_min: 2000.000000
     acceleration_mm_per_sec2: 50.000000
-    max_travel_mm: 5000.000000
-    soft_limits: false
+    max_travel_mm: 4000.000000
+    soft_limits: true
     homing: 
       cycle: -1
       allow_single_axis: true


### PR DESCRIPTION
This pull request enables the soft limits which prevent the belt from being allowed to extend out past where it would come off of the spool by enabling soft limits in the maslow.yaml file.

This PR has not been tested.