### PR TITLE
add submitting user to PR

### DIFF
--- a/.github/workflows/assign-copilot.yml
+++ b/.github/workflows/assign-copilot.yml
@@ -16,5 +16,6 @@ jobs:
         if: github.event.issue.user.login != 'BarbourSmith'
         run: |
           gh issue edit ${{ github.event.issue.number }} --add-assignee "copilot-swe-agent"
+          gh issue edit ${{ github.event.issue.number }} --add-assignee ithub.event.issue.user.login
         env:
           GH_TOKEN: ${{ secrets.USER_GITHUB_TOKEN }}


### PR DESCRIPTION
the separate process is not working/requires approval, so I decided to look at the assign to copilot workflow and try to add an assignee here.

This is just me looking at code and changing what seems reasonable. I don't know any of the rules for this, so it may fail