### PR TITLE
remove bar specific stuff

### DIFF
--- a/build-release.py
+++ b/build-release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Build FluidNC release bundles (.zip files) for each host platform
 
@@ -12,7 +12,7 @@ verbose = '-v' in sys.argv
 
 environ = dict(os.environ)
 
-platformio = r"/Users/barsmith/.platformio/penv/bin/platformio" #"/Users/barsmith/.platformio/penv/bin/platformio"
+platformio = r"platformio" #"/Users/barsmith/.platformio/penv/bin/platformio"
 
 # Extract version from git tag
 try:
@@ -28,7 +28,7 @@ except (subprocess.CalledProcessError, FileNotFoundError):
     version = "unknown"
     print("Warning: Could not determine version from git tags, using 'unknown'")
 
-os.chdir(os.path.dirname(os.path.realpath(r"/Users/barsmith/Documents/GitHub/FluidNC/.pio"))) #"/Users/barsmith/Documents/GitHub/FluidNC/.pio"
+#os.chdir(os.path.dirname(os.path.realpath(r"/Users/barsmith/Documents/GitHub/FluidNC/.pio"))) #"/Users/barsmith/Documents/GitHub/FluidNC/.pio"
 #change path to the project folder (the folder with platformio.ini)
 tag = "maslow4-"+version
 sharedPath = 'install_scripts'
@@ -191,9 +191,10 @@ for platform in ['win64', 'posix']:
 
 
         # Download and unzip from ESP repo
+            # with urllib.request.urlopen(EspRepo + ZipFileName, cafile=certifi.where()) as u:
         ZipFileName = EspDir + '.zip'
         if not os.path.isfile(ZipFileName):
-            with urllib.request.urlopen(EspRepo + ZipFileName, cafile=certifi.where()) as u:
+            with urllib.request.urlopen(EspRepo + ZipFileName) as u:
                 open(ZipFileName, 'wb').write(u.read())
 
         if withEsptoolBinary[platform]:


### PR DESCRIPTION
the build-release script had items in it specific to @BarbourSmith laptop

with those removed, platformio and pio need to be in your path and you need to run build-release from the top directory

also changed to specify python3 rather than just python (needs testing on mac)

with this done, I tested by doing 

tag v1.13.1
./build-release.py
cat FluidNC/src/version.cpp

and it shows the version as c1.13.1

