### PR TITLE
change version field size in header

### DIFF
--- a/FluidNC/src/Maslow/Maslow.h
+++ b/FluidNC/src/Maslow/Maslow.h
@@ -33,9 +33,9 @@ const std::string M = "Maslow";
 
 struct TelemetryFileHeader {
     unsigned int structureSize;  // 4 bytes
-    char         version[10];    // 10
+    char         version[30];    // 30
     // if you add to the header take bytes from this
-    char _unused[64];  // 64 bytes
+    char _unused[44];  // 44 bytes
 };
 
 struct TelemetryData {


### PR DESCRIPTION
the initial header only had 10 characters for the version number.  PR #481 added logic to avoid buffer overflows from the version number (it should have overflowed into a 64 byte empty field, but who knows what that field was populated with)

This PR expands the version field to 30 bytes to avoid the overflow/truncation from happening.

It may be that instead of this version being the release version, we should make it a format version that only changes when the format of TelemetryData changes, but that is a larger discussion