### PR TITLE
Fix transition from anchor point locating failure

### DIFF
--- a/firmware/FluidNC/src/Maslow/Calibration.cpp
+++ b/firmware/FluidNC/src/Maslow/Calibration.cpp
@@ -106,8 +106,8 @@ bool Calibration::requestStateChange(int newState) {
                 log_info("Cannot extend the belts until they have been retracted");
                 break;
             }
-        case EXTENDEDOUT:  //We can enter extended from extending or in the event of a failure from taking slack or release tension
-            if (currentState == EXTENDING || currentState == TAKING_SLACK || currentState == RELEASE_TENSION) {
+        case EXTENDEDOUT:  //We can enter extended from extending or in the event of a failure from taking slack, release tension, or calibration computing
+            if (currentState == EXTENDING || currentState == TAKING_SLACK || currentState == RELEASE_TENSION || currentState == CALIBRATION_COMPUTING) {
                 currentState = EXTENDEDOUT;
                 sys.set_state(State::Idle);
                 // Save belt positions now that belts are extended and at a known position


### PR DESCRIPTION
When the anchor point locating process failed it was getting stuck in the "Computing anchor points" state instead of transitioning back to the "Extended Out" state. This PR fixes that.