### PR TITLE
add scripts to simplify building your own test firmware

### DIFF
--- a/build
+++ b/build
@@ -1,0 +1,8 @@
+#!/bin/bash
+cd ESP3D-WEBUI
+npm run build:en
+cd ..
+cd firmware
+./build-release.py
+cd ..
+

--- a/firmware.bin
+++ b/firmware.bin
@@ -1,0 +1,1 @@
+firmware/.pio/build/wifi_s3/firmware.bin

--- a/index.html.gz
+++ b/index.html.gz
@@ -1,0 +1,1 @@
+ESP3D-WEBUI/dist/index.html.gz

--- a/update
+++ b/update
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 git fetch --tags -a `grep -A 1 '^\[branch \"Maslow-Main\"\]' .git/config  |grep remote |cut -f 3 -d ' '`
 b=`git branch |grep "^\*"|sed -e s/'\* .HEAD detached at '// -e s/'.$'//`
 git checkout Maslow-Main

--- a/update
+++ b/update
@@ -1,0 +1,6 @@
+#!/bin/bash
+git fetch --tags -a `grep -A 1 '^\[branch \"Maslow-Main\"\]' .git/config  |grep remote |cut -f 3 -d ' '`
+b=`git branch |grep "^\*"|sed -e s/'\* .HEAD detached at '// -e s/'.$'//`
+git checkout Maslow-Main
+git checkout $b
+./build


### PR DESCRIPTION
build builds both firmware and UI

symlinks for firmware.bin and index.html.gz so that you can point
  a browser at the git directlory to upload to the maslow

update
  fetches what branch you are on, fetches all updates from the
    repo that has Maslow-Main defined
    (This is named 'origin' by default, but can be changed)
  switches branches to get you on the latest version of the branch you were on.

With these changes, instead of asking the AI to build
  (and waiting, sometimes getting an error),
  you can instead checkout a branch for the PR like
```
git checkout -b origin/copilot/investigate-wifi-disconnect-issue
```
which will end up with you on a detached branch
then after a change is made you can do
```
./update
./build
```
then upload via the symlinks. This is a much faster turn-around

These can all be ignored by people who don't want to use them, so are low risk

I have tested these on linux (with the name for the maslow repo being 'bar' instead of 'origin') and they work and greatly speed up the turnaround compared to asking maslowbot to forward a request to copilot to build the firmware